### PR TITLE
[Style] 메인화면 - 로비(메인페이지) 내부 UserCard 컴포넌트

### DIFF
--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,4 +1,4 @@
-import * as Avatar from '@radix-ui/react-avatar';
+import UserCard from './UserCard';
 import UserList from './UserList';
 
 const MainPage = () => {
@@ -10,25 +10,7 @@ const MainPage = () => {
         <article className='flex items-center justify-center bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[4.5rem] w-full'>
           <button>전체 랭킹 보기</button>
         </article>
-        <article className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[18rem] w-full p-[1.2rem]'>
-          <div className='flex justify-between'>
-            <span>닉네임</span>
-            <i>♣</i>
-          </div>
-          <div className='py-[2.2rem] flex'>
-            <Avatar.Root className='w-1/2'>
-              <Avatar.Image
-                className='size-[9rem] rounded-full'
-                src='https://images.unsplash.com/photo-1492633423870-43d1cd2775eb?&w=128&h=128&dpr=2&q=80'
-                alt='프로필 이미지'
-              />
-              <Avatar.Fallback delayMs={1000}>테스트</Avatar.Fallback>
-            </Avatar.Root>
-            <div className='flex flex-col-reverse w-1/2'>
-              <span>무언가</span>
-            </div>
-          </div>
-        </article>
+        <UserCard />
       </section>
       <section className='flex-1 grid grid-cols-[3fr_1fr] grid-rows-[5rem_auto] grid-flow-col gap-[3rem]'>
         <article className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100'>

--- a/src/pages/MainPage/UserCard.tsx
+++ b/src/pages/MainPage/UserCard.tsx
@@ -1,0 +1,35 @@
+import * as Avatar from '@radix-ui/react-avatar';
+
+interface UserCardProps {
+  userImage?: string;
+  fallbackDelay?: number;
+}
+
+const UserCard = ({
+  userImage = 'https://images.unsplash.com/photo-1492633423870-43d1cd2775eb?&w=128&h=128&dpr=2&q=80',
+  fallbackDelay = 6000,
+}: UserCardProps) => {
+  return (
+    <article className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[18rem] w-full p-[1.2rem]'>
+      <div className='flex justify-between'>
+        <span>닉네임</span>
+        <i>♣</i>
+      </div>
+      <div className='py-[2.2rem] flex'>
+        <Avatar.Root className='w-1/2'>
+          <Avatar.Image
+            className='size-[9rem] rounded-full'
+            src={userImage}
+            alt='프로필 이미지'
+          />
+          <Avatar.Fallback delayMs={fallbackDelay}>테스트</Avatar.Fallback>
+        </Avatar.Root>
+        <div className='flex flex-col-reverse w-1/2'>
+          <span>무언가</span>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+export default UserCard;

--- a/src/pages/MainPage/UserCard.tsx
+++ b/src/pages/MainPage/UserCard.tsx
@@ -2,17 +2,22 @@ import * as Avatar from '@radix-ui/react-avatar';
 
 interface UserCardProps {
   userImage?: string;
-  fallbackDelay?: number;
+  userImageFallbackDelay?: number;
+  rank?: number;
 }
 
 const UserCard = ({
+  //테스트용으로 기본값 추가해두었습니다.
   userImage = 'https://images.unsplash.com/photo-1492633423870-43d1cd2775eb?&w=128&h=128&dpr=2&q=80',
-  fallbackDelay = 6000,
+  userImageFallbackDelay = 6000,
+  rank = 0,
 }: UserCardProps) => {
   return (
     <article className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[18rem] w-full p-[1.2rem]'>
       <div className='flex justify-between'>
-        <span>닉네임</span>
+        <span className='truncate flex-1'>
+          닉네임이겁나길수도있습니다이렇게
+        </span>
         <button>(수정)</button>
       </div>
       <div className='py-[2.2rem] flex'>
@@ -22,10 +27,12 @@ const UserCard = ({
             src={userImage}
             alt='프로필 이미지'
           />
-          <Avatar.Fallback delayMs={fallbackDelay}>테스트</Avatar.Fallback>
+          <Avatar.Fallback delayMs={userImageFallbackDelay}>
+            테스트
+          </Avatar.Fallback>
         </Avatar.Root>
         <div className='flex flex-col-reverse  mx-[1.2rem]'>
-          <span className='bg-coral-50 w-[6.8rem] text-center'>순위</span>
+          <span className='bg-coral-50 w-[6.8rem] text-center'>{`${rank ? `${rank}위` : '순위없음'}`}</span>
         </div>
       </div>
     </article>

--- a/src/pages/MainPage/UserCard.tsx
+++ b/src/pages/MainPage/UserCard.tsx
@@ -24,8 +24,8 @@ const UserCard = ({
           />
           <Avatar.Fallback delayMs={fallbackDelay}>테스트</Avatar.Fallback>
         </Avatar.Root>
-        <div className='flex flex-col-reverse w-1/2'>
-          <span>무언가</span>
+        <div className='flex flex-col-reverse  mx-[1.2rem]'>
+          <span className='bg-coral-50 w-[6.8rem] text-center'>순위</span>
         </div>
       </div>
     </article>

--- a/src/pages/MainPage/UserCard.tsx
+++ b/src/pages/MainPage/UserCard.tsx
@@ -13,7 +13,7 @@ const UserCard = ({
     <article className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[18rem] w-full p-[1.2rem]'>
       <div className='flex justify-between'>
         <span>닉네임</span>
-        <i>♣</i>
+        <button>(수정)</button>
       </div>
       <div className='py-[2.2rem] flex'>
         <Avatar.Root className='w-1/2'>


### PR DESCRIPTION
## 📋 Issue Number
close #

## 💻 구현 내용

- UserCard 컴포넌트 생성 및 UI구현
- 3개의 props (userImage, userImageFallbackDealy, rank)를 받아 뿌려줍니다

## 📷 Screenshots
![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/2cae99fe-6794-4503-af43-a06da89f2252)


## 🤔 고민사항
- UserCard에서 User라는 도메인 제거 후 Card로 만들면, 조금 더 쓰임새가 있지 않을까 고민중입니다...(게임 대기방에서도 활용가능?)
아니면 모양을 맞춰보는 것도 좋아보입니다
- 유저의 게임 데이터가 없을때 랭크가 없을까요? 아니면 0위 이렇게 표현하는게 좋을까용?

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
