### PR TITLE
[Feat] zustand 세팅, 게임모드 변경 store 이용

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-router-dom": "^6.22.0",
     "storybook": "^7.6.13",
     "tailwind-scrollbar-hide": "^1.1.7",
-    "zustand": "^4.5.0"
+    "zustand": "^4.5.1"
   },
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^5.18.1",

--- a/src/common/Backward/Backward.tsx
+++ b/src/common/Backward/Backward.tsx
@@ -1,17 +1,15 @@
-import { useNavigate } from 'react-router-dom';
 import backward from '@/assets/backward.png';
 
-const Backward = () => {
+const Backward = ({
+  handleClickBackward,
+}: {
+  handleClickBackward: () => void;
+}) => {
   // TODO: 예외처리 사항 필요하면 추후에 추가
-  const navigate = useNavigate();
-  const goPreviousPage = () => {
-    navigate(-1);
-  };
-
   return (
     <button
-      type='button'
-      onClick={goPreviousPage}>
+      onClick={handleClickBackward}
+      type='button'>
       <img
         src={backward}
         className='w-[4.8rem]'

--- a/src/common/Ingame/IngameHeader.tsx
+++ b/src/common/Ingame/IngameHeader.tsx
@@ -1,13 +1,15 @@
 import { gameInfoDummy } from '@/pages/GamePage/GameDummys';
+import useGameModeStore from '@/stores/useGameModeStore';
 import Backward from '../Backward/Backward';
 
 const IngameHeader = () => {
   const { gameRoomName, gameRoomUserList, gameRoundTotal } = gameInfoDummy; // TODO : 캐싱쿼리값
   const gameRoundCurrent = 2; //TODO: 현재 라운드로 수정. zustand?
+  const handleChandGameMode = useGameModeStore((state) => state.changeGameMode);
 
   return (
     <div className='flex flex-row items-center gap-20 pb-12'>
-      <Backward />
+      <Backward handleClickBackward={() => handleChandGameMode('waiting')} />
       <div className='w-[40rem] truncate text-4xl'>{gameRoomName}</div>
       <div className='grow'>참여 {gameRoomUserList.length}명</div>
       <div>

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -1,16 +1,15 @@
-import { useState } from 'react';
+import useGameModeStore from '@/stores/useGameModeStore';
 import GameCode from './GameCode/GameCode';
 import GameFinish from './GameFinish/GameFinish';
 import GameSentence from './GameSentence/GameSentence';
 import GameWaitingRoom from './GameWaitingRoom/GameWaitingRoom';
 import GameWord from './GameWord/GameWord';
 
-type GameModeType = 'waiting' | 'sentence' | 'code' | 'word' | 'finish';
 const GamePage = () => {
+  const gameMode = useGameModeStore((state) => state.mode); //현재 모드 상태값을 가져온다
   // TODO:
   // 여기서 zustand 전역상태값(초대로 들어온 사람이라면 url의 해시값->정제->유효검사 후 상태값) 으로 방번호 추출
   // 방번호를 가지고 게임 상태에 대해 api 요청
-  const [gameMode] = useState<GameModeType>('waiting');
 
   switch (gameMode) {
     case 'waiting':

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -10,7 +10,7 @@ const GamePage = () => {
   // TODO:
   // 여기서 zustand 전역상태값(초대로 들어온 사람이라면 url의 해시값->정제->유효검사 후 상태값) 으로 방번호 추출
   // 방번호를 가지고 게임 상태에 대해 api 요청
-  const [gameMode] = useState<GameModeType>('sentence');
+  const [gameMode] = useState<GameModeType>('waiting');
 
   switch (gameMode) {
     case 'waiting':

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomSetting.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomSetting.tsx
@@ -1,8 +1,17 @@
+import useGameModeStore from '@/stores/useGameModeStore';
+
 const GameRoomSetting = () => {
+  const moveCurrent = useGameModeStore((state) => state.mode); //현재 모드 상태값을 가져온다<!DOCTYPE html>
+  const handleClickTest = useGameModeStore((state) => state.changeGameMode); // 모드 변경 함수를 불러오는 것!! 넘겨주는건 호출할 때!
+
   return (
-    <div className='w-[20%] flex justify-center items-center'>
+    <div
+      onClick={() => {
+        handleClickTest('code');
+      }}
+      className='w-[20%] flex justify-center items-center'>
       <button className='w-[8rem] aspect-square text-white text-[2rem] bg-gray-300/90 hover:bg-gray-200 transition-all duration-300 shadow-md shadow-black/50 rounded-[2.5rem]'>
-        변경
+        변경 {moveCurrent}
       </button>
     </div>
   );

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomSetting.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomSetting.tsx
@@ -1,17 +1,18 @@
 import useGameModeStore from '@/stores/useGameModeStore';
 
 const GameRoomSetting = () => {
-  const moveCurrent = useGameModeStore((state) => state.mode); //현재 모드 상태값을 가져온다<!DOCTYPE html>
-  const handleClickTest = useGameModeStore((state) => state.changeGameMode); // 모드 변경 함수를 불러오는 것!! 넘겨주는건 호출할 때!
+  const handleChangeGameMode = useGameModeStore(
+    (state) => state.changeGameMode
+  );
 
   return (
     <div
       onClick={() => {
-        handleClickTest('code');
+        handleChangeGameMode('word');
       }}
       className='w-[20%] flex justify-center items-center'>
       <button className='w-[8rem] aspect-square text-white text-[2rem] bg-gray-300/90 hover:bg-gray-200 transition-all duration-300 shadow-md shadow-black/50 rounded-[2.5rem]'>
-        변경 {moveCurrent}
+        변경
       </button>
     </div>
   );

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import Backward from '@/common/Backward/Backward';
 import { gameInfoDummy } from '../GameDummys';
 import GameModeInfo from './GameModeInfo';
@@ -9,10 +10,12 @@ import GameRoomUserList from './GameRoomUserList';
 
 const GameWaitingRoom = () => {
   const { gameRoomUserList } = gameInfoDummy;
+  const navigate = useNavigate();
+
   return (
     <div className='w-full flex flex-col justify-center items-center gap-[3rem] select-none'>
       <header className='flex gap-[5rem]'>
-        <Backward />
+        <Backward handleClickBackward={() => navigate(-1)} />
         <GameRoomInfo {...gameInfoDummy} />
       </header>
       <GameRoomUserList gameRoomUserList={gameRoomUserList} />

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -89,15 +89,13 @@ const GameWord = () => {
                 {wordRankDummy.map((rank, i) => {
                   const { userId, userName, score } = rank;
                   return (
-                    <>
-                      <WordRank
-                        key={i}
-                        track={i}
-                        userId={userId}
-                        userName={userName}
-                        score={score}
-                      />
-                    </>
+                    <WordRank
+                      key={i}
+                      track={i}
+                      userId={userId}
+                      userName={userName}
+                      score={score}
+                    />
                   );
                 })}
               </div>

--- a/src/stores/useGameModeStore.ts
+++ b/src/stores/useGameModeStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+
+type GameModeType = 'waiting' | 'sentence' | 'code' | 'word' | 'finish';
+interface I_UseGameModeStore {
+  mode: GameModeType;
+  changeGameMode: (value: GameModeType) => void;
+}
+
+const useGameModeStore = create<I_UseGameModeStore>((set) => ({
+  mode: 'waiting',
+  changeGameMode: (value) => set({ mode: value }),
+}));
+
+export default useGameModeStore;

--- a/src/stores/useGameModeStore.ts
+++ b/src/stores/useGameModeStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
+import { GameModeType } from '@/types/GameModeType';
 
-type GameModeType = 'waiting' | 'sentence' | 'code' | 'word' | 'finish';
 interface I_UseGameModeStore {
   mode: GameModeType;
   changeGameMode: (value: GameModeType) => void;

--- a/src/types/GameModeType.ts
+++ b/src/types/GameModeType.ts
@@ -1,0 +1,1 @@
+export type GameModeType = 'waiting' | 'sentence' | 'code' | 'word' | 'finish';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9767,7 +9767,7 @@ __metadata:
     typescript: "npm:^5.2.2"
     vite: "npm:^5.0.8"
     vitest: "npm:^1.3.0"
-    zustand: "npm:^4.5.0"
+    zustand: "npm:^4.5.1"
   languageName: unknown
   linkType: soft
 
@@ -10720,9 +10720,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zustand@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "zustand@npm:4.5.0"
+"zustand@npm:^4.5.1":
+  version: 4.5.1
+  resolution: "zustand@npm:4.5.1"
   dependencies:
     use-sync-external-store: "npm:1.2.0"
   peerDependencies:
@@ -10736,6 +10736,6 @@ __metadata:
       optional: true
     react:
       optional: true
-  checksum: 10c0/4802c4e26f2c1ec0d8e0ce8e596413cafb8b3d383e664de4eb30af63cedd23686f17b96a8a4d4583fc4470b187de0bbeafcfb94894efc50f6e62813e02a70b64
+  checksum: 10c0/3c928236f716f026760ddfff9910c37f9e3696169650cd677139dc2fe2623fa215dc31c899caf5b9b6a0668ed003c505918c2a953dbbd295fe7f90092634a90c
   languageName: node
   linkType: hard


### PR DESCRIPTION
## 📋 Issue Number
close #46

## 💻 구현 내용

- zustand 세팅
- useGameModeStore에 게임모드 관리 store 생성
- 현재, 테스트용으로 대기실의 [변경] 버튼 누르면 게임으로 이동 

## 📷 Screenshots

https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/81412212/0b63e138-fc75-4e60-ae5d-b7b1de97f6aa


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
* store 새로고침 저장 관련 오늘자 회의록에 적어두었습니다.
* useGameModeStore, handleClickBackward 등 명명이 너무 길까요?
<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
