### PR TITLE
[Feat] 게임룸 웹소켓 - 다른 유저 참여시 기존 모든 유저들의 목록 갱신

### DIFF
--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -1,7 +1,6 @@
 import { Stomp } from '@stomp/stompjs';
 import { useEffect, useState } from 'react';
 import { I_GameRoomResponse } from '@/ws/types/wsResType';
-// import useWebsocket from '@/ws/useWebsocket';
 import GameCode from './GameCode/GameCode';
 import GameFinish from './GameFinish/GameFinish';
 import GameSentence from './GameSentence/GameSentence';
@@ -72,27 +71,27 @@ const GamePage = () => {
   // TODO:
   // 여기서 zustand 전역상태값(초대로 들어온 사람이라면 url의 해시값->정제->유효검사 후 상태값) 으로 방번호 추출
   // 방번호를 가지고 게임 상태에 대해 api 요청
-  // const { initWebsocket } = useWebsocket();
 
-  const [gameMode] = useState<GameModeType>('waiting'); //,,,
+  const gameMode: GameModeType = 'waiting';
 
-  switch (gameMode) {
-    case 'waiting':
-      return (
-        'roomId' in gameRoomInfo && (
+  return (
+    <>
+      {'roomId' in gameRoomInfo ? (
+        gameMode === 'waiting' ? (
           <GameWaitingRoom gameRoomInfo={gameRoomInfo} />
+        ) : gameMode === 'sentence' ? (
+          <GameSentence />
+        ) : gameMode === 'code' ? (
+          <GameCode />
+        ) : gameMode === 'word' ? (
+          <GameWord />
+        ) : (
+          <GameFinish />
         )
-      );
-    case 'sentence':
-      return <GameSentence />;
-    case 'code':
-      return <GameCode />;
-    case 'word':
-      return <GameWord />;
-    case 'finish':
-      return <GameFinish />;
-    default:
-      return <GameWaitingRoom />;
-  }
+      ) : (
+        <div>소켓오류</div>
+      )}
+    </>
+  );
 };
 export default GamePage;

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -1,22 +1,20 @@
 import { CompatClient, Stomp } from '@stomp/stompjs';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { guestLogin } from '@/apis/api';
+import storageFactory from '@/utils/storageFactory';
+import { WS_END_POINT } from '@/ws/endpoint';
 import { I_GameRoomResponse } from '@/ws/types/wsResType';
 import GameCode from './GameCode/GameCode';
 import GameSentence from './GameSentence/GameSentence';
 import GameWaitingRoom from './GameWaitingRoom/GameWaitingRoom';
 import GameWord from './GameWord/GameWord';
-const { VITE_API_WS_END_POINT } = import.meta.env;
-import { guestLogin } from '@/apis/api';
-import storageFactory from '@/utils/storageFactory';
 
 const GamePage = () => {
   const [gameRoomInfo, setGameRoomInfo] = useState({} as I_GameRoomResponse);
   const ws = useRef<CompatClient | null>(null);
 
   useEffect(() => {
-    const stompClient = Stomp.over(
-      () => new SockJS(`${VITE_API_WS_END_POINT}`)
-    );
+    const stompClient = Stomp.over(() => new SockJS(`${WS_END_POINT}`));
 
     // 테스트용 로그인 로직
     const { getItem, setItem } = storageFactory(localStorage);

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -8,6 +8,7 @@ import { I_GameRoomResponse } from '@/ws/types/wsResType';
 import GameCode from './GameCode/GameCode';
 import GameSentence from './GameSentence/GameSentence';
 import GameWaitingRoom from './GameWaitingRoom/GameWaitingRoom';
+import WsError from './GameWaitingRoom/WsError';
 import GameWord from './GameWord/GameWord';
 
 const GamePage = () => {
@@ -32,7 +33,7 @@ const GamePage = () => {
       Authorization: `Bearer ${token}`,
     };
 
-    const ROOMID_TEST = 13; // 테스트용 RoomId ////////////////////////////////////
+    const ROOMID_TEST = 35; // 테스트용 RoomId ////////////////////////////////////
 
     const onConnected = () => {
       //TODO: roomId는 방입장 GET요청 응답값으로 사용
@@ -79,7 +80,7 @@ const GamePage = () => {
   ); //모두 준비인상태에서 방장이 시작했다면 'START' type 이 옴
 
   if (!isSuccess) {
-    return <div>소켓 연결 실패시 // TODO</div>;
+    return <WsError />;
   }
   return (
     <>

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -1,20 +1,88 @@
-import { useState } from 'react';
+import { Stomp } from '@stomp/stompjs';
+import { useEffect, useState } from 'react';
+import { I_GameRoomResponse } from '@/ws/types/wsResType';
+// import useWebsocket from '@/ws/useWebsocket';
 import GameCode from './GameCode/GameCode';
 import GameFinish from './GameFinish/GameFinish';
 import GameSentence from './GameSentence/GameSentence';
 import GameWaitingRoom from './GameWaitingRoom/GameWaitingRoom';
 import GameWord from './GameWord/GameWord';
+const { VITE_API_WS_END_POINT } = import.meta.env;
+import { guestLogin } from '@/apis/api';
+import storageFactory from '@/utils/storageFactory';
 
 type GameModeType = 'waiting' | 'sentence' | 'code' | 'word' | 'finish';
 const GamePage = () => {
+  const [gameRoomInfo, setGameRoomInfo] = useState({} as I_GameRoomResponse);
+
+  useEffect(() => {
+    const stompClient = Stomp.over(
+      () => new SockJS(`${VITE_API_WS_END_POINT}`)
+    );
+
+    // 테스트용 로그인 로직
+    const { getItem, setItem } = storageFactory(localStorage);
+    const guestLoginFn = async () => {
+      const { data } = await guestLogin();
+      setItem('token', data.data.accessToken);
+      token = data.data.accessToken;
+    };
+    let token = getItem('token', '');
+    if (!token) {
+      guestLoginFn();
+    }
+    const connectHeaders = {
+      Authorization: 'Bearer ' + token,
+    };
+
+    const ROOMID_TEST = 8; // 테스트용 RoomId ////////////////////////////////////
+
+    const onConnected = () => {
+      //TODO: roomId는 방입장 GET요청 응답값으로 사용
+      stompClient.subscribe(
+        `/from/game-room/${ROOMID_TEST}`,
+        (e) => onMessageReceived(e),
+        connectHeaders
+      );
+      stompClient.subscribe(
+        `/from/game-room/${ROOMID_TEST}/error`,
+        // eslint-disable-next-line no-console
+        (e) => console.log('----subscribe error----', e),
+        connectHeaders
+      );
+      stompClient.send(
+        `/to/game-room/${ROOMID_TEST}/enter`,
+        connectHeaders,
+        '입장~'
+      );
+    };
+    const onMessageReceived = ({ body }: { body: string }) => {
+      const responsePublish = JSON.parse(body);
+      // called when the client receives a STOMP message from the server
+      // eslint-disable-next-line no-console
+      console.log('onMessageReceived---', responsePublish);
+      setGameRoomInfo(responsePublish);
+    };
+
+    stompClient.connect({ Authorization: `Bearer ${token}` }, () => {
+      onConnected();
+    });
+  }, []);
+
   // TODO:
   // 여기서 zustand 전역상태값(초대로 들어온 사람이라면 url의 해시값->정제->유효검사 후 상태값) 으로 방번호 추출
   // 방번호를 가지고 게임 상태에 대해 api 요청
-  const [gameMode] = useState<GameModeType>('waiting');
+  // const { initWebsocket } = useWebsocket();
+
+  const [gameMode] = useState<GameModeType>('waiting'); //,,,
 
   switch (gameMode) {
     case 'waiting':
-      return <GameWaitingRoom />;
+      return (
+        'roomId' in gameRoomInfo && (
+          <GameWaitingRoom gameRoomInfo={gameRoomInfo} />
+        )
+      );
     case 'sentence':
       return <GameSentence />;
     case 'code':

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -1,6 +1,7 @@
 import { CompatClient, Stomp } from '@stomp/stompjs';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { guestLogin } from '@/apis/api';
+import { checkEmptyObj } from '@/utils/checkEmptyObj';
 import storageFactory from '@/utils/storageFactory';
 import { WS_END_POINT } from '@/ws/endpoint';
 import { I_GameRoomResponse } from '@/ws/types/wsResType';
@@ -31,7 +32,7 @@ const GamePage = () => {
       Authorization: `Bearer ${token}`,
     };
 
-    const ROOMID_TEST = 12; // 테스트용 RoomId ////////////////////////////////////
+    const ROOMID_TEST = 13; // 테스트용 RoomId ////////////////////////////////////
 
     const onConnected = () => {
       //TODO: roomId는 방입장 GET요청 응답값으로 사용
@@ -67,10 +68,7 @@ const GamePage = () => {
     ws.current = stompClient;
   }, []);
 
-  const isSuccess = useMemo(
-    () => Object.keys(gameRoomInfo).length !== 0,
-    [gameRoomInfo]
-  );
+  const isSuccess = useMemo(() => !checkEmptyObj(gameRoomInfo), [gameRoomInfo]);
   const selectedMode = useMemo(
     () => gameRoomInfo.roomInfo?.gameMode,
     [gameRoomInfo.roomInfo?.gameMode]

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomInfo.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomInfo.tsx
@@ -1,4 +1,5 @@
 import { I_GameRoomResponse } from '@/ws/types/wsResType';
+import { GAME_TYPE } from '../constants';
 
 const GameRoomInfo = ({
   gameRoomInfo,
@@ -8,13 +9,14 @@ const GameRoomInfo = ({
   return (
     <div className='w-[105rem] h-[7.1rem] text-[2rem] flex bg-beige-100 rounded-[2.5rem] shadow-md shadow-black/50 items-center '>
       <div className='flex justify-center items-center w-[25%] h-[70%] border-r border-solid border-black'>
-        {gameRoomInfo.roomId}
+        No.{gameRoomInfo.roomId}
       </div>
       <div className='flex justify-center items-center w-[35%] h-[70%] border-r border-solid border-black'>
         {gameRoomInfo.roomInfo?.title}
       </div>
       <div className='flex justify-center items-center w-[20%] h-[70%] border-r border-solid border-black'>
-        {gameRoomInfo.roomInfo?.mode}
+        {gameRoomInfo.roomInfo &&
+          GAME_TYPE.get(gameRoomInfo.roomInfo?.gameMode)}
       </div>
       <div className='flex justify-center items-center w-[20%] h-[70%]'>{`${gameRoomInfo.allMembers?.length} / ${gameRoomInfo.roomInfo?.maxPlayer}`}</div>
     </div>

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomInfo.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomInfo.tsx
@@ -1,24 +1,22 @@
-import { I_GameInfo } from '../types/gameInfoType';
+import { I_AllMember, I_RoomInfo } from '@/ws/types/wsResType';
 
-const GameRoomInfo = ({
-  gameRoomId,
-  gameRoomName,
-  gameMode,
-  gameRoomMaximumHeadCount,
-  gameRoomUserList,
-}: I_GameInfo) => {
+interface GameRoomInfoProps {
+  roomInfo: I_RoomInfo;
+  allMembers: I_AllMember[];
+}
+const GameRoomInfo = ({ roomInfo, allMembers }: GameRoomInfoProps) => {
   return (
     <div className='w-[105rem] h-[7.1rem] text-[2rem] flex bg-beige-100 rounded-[2.5rem] shadow-md shadow-black/50 items-center '>
       <div className='flex justify-center items-center w-[25%] h-[70%] border-r border-solid border-black'>
-        {gameRoomId}
+        {roomInfo.id}
       </div>
       <div className='flex justify-center items-center w-[35%] h-[70%] border-r border-solid border-black'>
-        {gameRoomName}
+        {roomInfo.title}
       </div>
       <div className='flex justify-center items-center w-[20%] h-[70%] border-r border-solid border-black'>
-        {gameMode}
+        {roomInfo.mode}
       </div>
-      <div className='flex justify-center items-center w-[20%] h-[70%]'>{`${gameRoomUserList.length} / ${gameRoomMaximumHeadCount}`}</div>
+      <div className='flex justify-center items-center w-[20%] h-[70%]'>{`${allMembers.length} / ${roomInfo.maxPlayer}`}</div>
     </div>
   );
 };

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomInfo.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomInfo.tsx
@@ -1,22 +1,22 @@
-import { I_AllMember, I_RoomInfo } from '@/ws/types/wsResType';
+import { I_GameRoomResponse } from '@/ws/types/wsResType';
 
-interface GameRoomInfoProps {
-  roomInfo: I_RoomInfo;
-  allMembers: I_AllMember[];
-}
-const GameRoomInfo = ({ roomInfo, allMembers }: GameRoomInfoProps) => {
+const GameRoomInfo = ({
+  gameRoomInfo,
+}: {
+  gameRoomInfo: I_GameRoomResponse;
+}) => {
   return (
     <div className='w-[105rem] h-[7.1rem] text-[2rem] flex bg-beige-100 rounded-[2.5rem] shadow-md shadow-black/50 items-center '>
       <div className='flex justify-center items-center w-[25%] h-[70%] border-r border-solid border-black'>
-        {roomInfo.id}
+        {gameRoomInfo.roomId}
       </div>
       <div className='flex justify-center items-center w-[35%] h-[70%] border-r border-solid border-black'>
-        {roomInfo.title}
+        {gameRoomInfo.roomInfo?.title}
       </div>
       <div className='flex justify-center items-center w-[20%] h-[70%] border-r border-solid border-black'>
-        {roomInfo.mode}
+        {gameRoomInfo.roomInfo?.mode}
       </div>
-      <div className='flex justify-center items-center w-[20%] h-[70%]'>{`${allMembers.length} / ${roomInfo.maxPlayer}`}</div>
+      <div className='flex justify-center items-center w-[20%] h-[70%]'>{`${gameRoomInfo.allMembers?.length} / ${gameRoomInfo.roomInfo?.maxPlayer}`}</div>
     </div>
   );
 };

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
@@ -1,13 +1,9 @@
 import * as Avatar from '@radix-ui/react-avatar';
 import close from '@/assets/close.png';
-import { I_GameRoomUserCard } from '../types/gameInfoType';
+import { I_AllMember } from '@/ws/types/wsResType';
 
-const GameRoomUserItem = ({
-  userName,
-  rank,
-  userImage,
-  userImageFallbackDelay,
-}: I_GameRoomUserCard) => {
+const GameRoomUserItem = ({ nickname }: I_AllMember) => {
+  const rank = 3; // memberId로 회원조회!!
   return (
     <div className='w-[25.8rem] h-[21.2rem] flex flex-col bg-white shadow-md shadow-black/50 rounded-[2.5rem]'>
       <button className='self-end pt-[1.6rem] pr-[1.6rem] '>
@@ -21,16 +17,17 @@ const GameRoomUserItem = ({
         <Avatar.Root className='w-1/2 self-center'>
           <Avatar.Image
             className='size-[10rem] rounded-full'
-            src={userImage}
+            src={
+              'https://images.unsplash.com/photo-1492633423870-43d1cd2775eb?&w=128&h=128&dpr=2&q=80'
+            }
             alt='프로필 이미지'
           />
-          <Avatar.Fallback delayMs={userImageFallbackDelay}>
-            test
-          </Avatar.Fallback>
+          {/*임시 이미지*/}
+          <Avatar.Fallback delayMs={6000}>test</Avatar.Fallback>
         </Avatar.Root>
         <div className='w-1/2 flex flex-col items-center justify-around text-center'>
-          <div className='w-[10rem] py-[0.4rem] bg-green-70 rounded-[2.5rem] '>
-            {userName}
+          <div className='w-[10rem] py-[0.4rem] bg-green-70 rounded-[2.5rem]'>
+            {nickname}
           </div>
           <div className='w-[10rem] py-[0.4rem] bg-green-70 rounded-[2.5rem]'>
             {rank}등

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomUserList.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomUserList.tsx
@@ -1,17 +1,17 @@
-import { I_GameRoomUserCard } from '../types/gameInfoType';
+import { I_AllMember } from '@/ws/types/wsResType';
 import GameRoomUserItem from './GameRoomUserItem';
 
 const GameRoomUserList = ({
   gameRoomUserList,
 }: {
-  gameRoomUserList: Array<I_GameRoomUserCard>;
+  gameRoomUserList: I_AllMember[];
 }) => {
   return (
     <>
       <main className='flex-1 grid grid-rows-2 grid-cols-4 gap-x-[4rem] gap-y-[3rem]'>
         {gameRoomUserList.map((gameRoomUser) => (
           <GameRoomUserItem
-            key={gameRoomUser.userName}
+            key={gameRoomUser.memberId}
             {...gameRoomUser}
           />
         ))}

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomUserList.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomUserList.tsx
@@ -9,12 +9,13 @@ const GameRoomUserList = ({
   return (
     <>
       <main className='flex-1 grid grid-rows-2 grid-cols-4 gap-x-[4rem] gap-y-[3rem]'>
-        {gameRoomUserList.map((gameRoomUser) => (
-          <GameRoomUserItem
-            key={gameRoomUser.memberId}
-            {...gameRoomUser}
-          />
-        ))}
+        {gameRoomUserList &&
+          gameRoomUserList.map((gameRoomUser) => (
+            <GameRoomUserItem
+              key={gameRoomUser.memberId}
+              {...gameRoomUser}
+            />
+          ))}
       </main>
     </>
   );

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -1,6 +1,5 @@
 import Backward from '@/common/Backward/Backward';
-import Ws from '@/ws/Ws';
-import { gameInfoDummy } from '../GameDummys';
+import { I_GameRoomResponse } from '@/ws/types/wsResType';
 import GameModeInfo from './GameModeInfo';
 import GameReadyAndStart from './GameReadyAndStart';
 import GameRoomInfo from './GameRoomInfo';
@@ -8,15 +7,23 @@ import GameRoomLinkInvitation from './GameRoomLinkInvitation';
 import GameRoomSetting from './GameRoomSetting';
 import GameRoomUserList from './GameRoomUserList';
 
-const GameWaitingRoom = () => {
-  const { gameRoomUserList } = gameInfoDummy;
+const GameWaitingRoom = ({
+  gameRoomInfo,
+}: {
+  gameRoomInfo: I_GameRoomResponse;
+}) => {
+  const { roomInfo, allMembers } = gameRoomInfo;
+
   return (
     <div className='w-full flex flex-col justify-center items-center gap-[3rem] select-none'>
       <header className='flex gap-[5rem]'>
         <Backward />
-        <GameRoomInfo {...gameInfoDummy} />
+        <GameRoomInfo
+          roomInfo={roomInfo}
+          allMembers={allMembers}
+        />
       </header>
-      <GameRoomUserList gameRoomUserList={gameRoomUserList} />
+      <GameRoomUserList gameRoomUserList={allMembers} />
       <footer className='w-[114.8rem] flex gap-[5rem]'>
         <GameModeInfo>
           <GameRoomSetting />
@@ -24,7 +31,6 @@ const GameWaitingRoom = () => {
         <GameRoomLinkInvitation />
         <GameReadyAndStart />
       </footer>
-      <Ws />
     </div>
   );
 };

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -12,18 +12,15 @@ const GameWaitingRoom = ({
 }: {
   gameRoomInfo: I_GameRoomResponse;
 }) => {
-  const { roomInfo, allMembers } = gameRoomInfo;
+  const { allMembers } = gameRoomInfo;
 
   return (
     <div className='w-full flex flex-col justify-center items-center gap-[3rem] select-none'>
       <header className='flex gap-[5rem]'>
         <Backward />
-        <GameRoomInfo
-          roomInfo={roomInfo}
-          allMembers={allMembers}
-        />
+        <GameRoomInfo gameRoomInfo={gameRoomInfo} />
       </header>
-      <GameRoomUserList gameRoomUserList={allMembers} />
+      {allMembers && <GameRoomUserList gameRoomUserList={allMembers} />}
       <footer className='w-[114.8rem] flex gap-[5rem]'>
         <GameModeInfo>
           <GameRoomSetting />

--- a/src/pages/GamePage/GameWaitingRoom/WsError.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/WsError.tsx
@@ -1,0 +1,4 @@
+const WsError = () => {
+  return <div className='bg-white '>서버와의 연결에 실패했습니다...</div>;
+};
+export default WsError;

--- a/src/pages/GamePage/constants.ts
+++ b/src/pages/GamePage/constants.ts
@@ -1,0 +1,5 @@
+export const GAME_TYPE = new Map([
+  ['WORD', '단어 게임'],
+  ['SENTENCE', '문장 게임'],
+  ['CODE', '코드 게임'],
+]);

--- a/src/utils/checkEmptyObj.ts
+++ b/src/utils/checkEmptyObj.ts
@@ -1,0 +1,3 @@
+export const checkEmptyObj = (obj: object) => {
+  return Object.keys(obj).length === 0;
+};

--- a/src/ws/endpoint.ts
+++ b/src/ws/endpoint.ts
@@ -1,0 +1,2 @@
+export const WS_END_POINT =
+  'http://ec2-43-200-61-201.ap-northeast-2.compute.amazonaws.com/ws';

--- a/src/ws/types/wsResType.ts
+++ b/src/ws/types/wsResType.ts
@@ -1,0 +1,35 @@
+export interface I_GameRoomResponse {
+  type:
+    | 'ENTER'
+    | 'EXIT'
+    | 'READY'
+    | 'START'
+    | 'START_DENIED'
+    | 'FINISH'
+    | 'ROUND_START'
+    | 'KICKED'
+    | 'UPDATE'
+    | 'WORD_DENIED';
+  roomId: number;
+  roomInfo: I_RoomInfo;
+  allMembers: I_AllMember[];
+}
+
+export interface I_RoomInfo {
+  id: number;
+  hostId: number;
+  title: string;
+  gameMode: 'WORD' | 'CODE' | 'SENTENCE';
+  inviteCode: string | null;
+  maxPlayer: number;
+  currentPlayer: number;
+  isPlaying: boolean;
+  isPrivate: boolean;
+  mode: string;
+}
+
+export interface I_AllMember {
+  memberId: number;
+  nickname: string;
+  readyStatus: boolean;
+}

--- a/src/ws/types/wsResType.ts
+++ b/src/ws/types/wsResType.ts
@@ -11,8 +11,8 @@ export interface I_GameRoomResponse {
     | 'UPDATE'
     | 'WORD_DENIED';
   roomId: number;
-  roomInfo: I_RoomInfo;
-  allMembers: I_AllMember[];
+  roomInfo?: I_RoomInfo;
+  allMembers?: I_AllMember[];
 }
 
 export interface I_RoomInfo {


### PR DESCRIPTION
## 📋 Issue Number
close #

## 💻 구현 내용

- GamePage 렌더링시(useEffect) 웹소켓에 연결하도록 했습니다
  - 현재, 이전 메인페이지 화면에 연결되있지는 않아서 postman을 사용하여 따로 생성/입장 REST요청을 보내야합니다.
- 구독한 채널로부터 받은 응답을 GameWaitingRoom에 넘겨줍니다

## 📷 Screenshots

https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/81412212/ccd025be-f86e-4d16-b66f-c5fe6f2c8cbb



## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
* 웹소켓 연결부 호출을 GamePage 로 두었는데 따로 훅을 두는게 나을까요?


### TODO

- [ ] 연결 오류 혹은 연결중일때 화면 (스켈레톤 등)

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->

---
** -# 40- 브랜치로부터 분기해서 PR base를 해당 브랜치로 두었습니다!