### PR TITLE
[Feat] 유저 준비 상태 반영, 방장 표기

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@openapitools/openapi-generator-cli": "^2.9.0",
+    "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-form": "^0.0.3",

--- a/src/common/Backward/Backward.tsx
+++ b/src/common/Backward/Backward.tsx
@@ -1,18 +1,14 @@
-import { useNavigate } from 'react-router-dom';
 import backward from '@/assets/backward.png';
 
-const Backward = () => {
-  // TODO: 예외처리 사항 필요하면 추후에 추가
-  const navigate = useNavigate();
-  const goPreviousPage = () => {
-    navigate('/main');
-    window.location.reload();
-  };
-
+const Backward = ({
+  handleClickBackward,
+}: {
+  handleClickBackward: () => void;
+}) => {
   return (
     <button
       type='button'
-      onClick={goPreviousPage}>
+      onClick={handleClickBackward}>
       <img
         src={backward}
         className='w-[4.8rem]'

--- a/src/common/Backward/Backward.tsx
+++ b/src/common/Backward/Backward.tsx
@@ -5,7 +5,8 @@ const Backward = () => {
   // TODO: 예외처리 사항 필요하면 추후에 추가
   const navigate = useNavigate();
   const goPreviousPage = () => {
-    navigate(-1);
+    navigate('/main');
+    window.location.reload();
   };
 
   return (

--- a/src/common/Header/Header.tsx
+++ b/src/common/Header/Header.tsx
@@ -40,7 +40,10 @@ const Header = () => {
   return (
     <header className='bg-green-100 h-[4.5rem] w-[100%] shrink-0 flex justify-between px-[4rem]'>
       <section
-        onClick={() => navigate('./main')}
+        onClick={() => {
+          navigate('./main');
+          navigate(0);
+        }}
         className='h-full flex items-center cursor-pointer'>
         <img
           src={logo_car}

--- a/src/generated/.openapi-generator/FILES
+++ b/src/generated/.openapi-generator/FILES
@@ -1,6 +1,5 @@
 .gitignore
 .npmignore
-.openapi-generator-ignore
 api.ts
 base.ts
 common.ts

--- a/src/generated/api.ts
+++ b/src/generated/api.ts
@@ -26,6 +26,62 @@ import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError, operationServerM
 /**
  * 
  * @export
+ * @interface AccountGetResponse
+ */
+export interface AccountGetResponse {
+    /**
+     * 
+     * @type {number}
+     * @memberof AccountGetResponse
+     */
+    'memberId': number;
+    /**
+     * 
+     * @type {string}
+     * @memberof AccountGetResponse
+     */
+    'email'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AccountGetResponse
+     */
+    'nickname': string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof AccountGetResponse
+     */
+    'isGuest': boolean;
+}
+/**
+ * 
+ * @export
+ * @interface ApiResponseAccountGetResponse
+ */
+export interface ApiResponseAccountGetResponse {
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiResponseAccountGetResponse
+     */
+    'code': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiResponseAccountGetResponse
+     */
+    'message': string;
+    /**
+     * 
+     * @type {AccountGetResponse}
+     * @memberof ApiResponseAccountGetResponse
+     */
+    'data'?: AccountGetResponse;
+}
+/**
+ * 
+ * @export
  * @interface ApiResponseAuthResponse
  */
 export interface ApiResponseAuthResponse {
@@ -46,7 +102,7 @@ export interface ApiResponseAuthResponse {
      * @type {AuthResponse}
      * @memberof ApiResponseAuthResponse
      */
-    'data': AuthResponse;
+    'data'?: AuthResponse;
 }
 /**
  * 
@@ -126,27 +182,27 @@ export interface ApiResponseGameRoomInviteCodeResponse {
 /**
  * 
  * @export
- * @interface ApiResponseMemberGetResponse
+ * @interface ApiResponseListMemberRankResponse
  */
-export interface ApiResponseMemberGetResponse {
+export interface ApiResponseListMemberRankResponse {
     /**
      * 
      * @type {string}
-     * @memberof ApiResponseMemberGetResponse
+     * @memberof ApiResponseListMemberRankResponse
      */
     'code': string;
     /**
      * 
      * @type {string}
-     * @memberof ApiResponseMemberGetResponse
+     * @memberof ApiResponseListMemberRankResponse
      */
     'message': string;
     /**
      * 
-     * @type {MemberGetResponse}
-     * @memberof ApiResponseMemberGetResponse
+     * @type {Array<MemberRankResponse>}
+     * @memberof ApiResponseListMemberRankResponse
      */
-    'data'?: MemberGetResponse;
+    'data'?: Array<MemberRankResponse>;
 }
 /**
  * 
@@ -390,33 +446,39 @@ export interface LoginRequest {
 /**
  * 
  * @export
- * @interface MemberGetResponse
+ * @interface MemberRankResponse
  */
-export interface MemberGetResponse {
+export interface MemberRankResponse {
     /**
      * 
      * @type {number}
-     * @memberof MemberGetResponse
+     * @memberof MemberRankResponse
      */
     'memberId': number;
     /**
      * 
      * @type {string}
-     * @memberof MemberGetResponse
-     */
-    'email': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof MemberGetResponse
+     * @memberof MemberRankResponse
      */
     'nickname': string;
     /**
      * 
-     * @type {string}
-     * @memberof MemberGetResponse
+     * @type {number}
+     * @memberof MemberRankResponse
      */
-    'status': string;
+    'totalScore': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof MemberRankResponse
+     */
+    'averageWpm': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof MemberRankResponse
+     */
+    'averageAccuracy': number;
 }
 /**
  * 
@@ -615,6 +677,45 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(gameRoomEnterRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary 랭킹 조회
+         * @param {string} [gameType] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getMemberRanking: async (gameType?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/ranks`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            if (gameType !== undefined) {
+                localVarQueryParameter['gameType'] = gameType;
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1025,11 +1126,24 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary 랭킹 조회
+         * @param {string} [gameType] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getMemberRanking(gameType?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponseListMemberRankResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getMemberRanking(gameType, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.getMemberRanking']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
          * @summary 내 프로필 조회
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getMyProfileInfo(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponseMemberGetResponse>> {
+        async getMyProfileInfo(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponseAccountGetResponse>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.getMyProfileInfo(options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.getMyProfileInfo']?.[localVarOperationServerIndex]?.url;
@@ -1184,11 +1298,21 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
+         * @summary 랭킹 조회
+         * @param {string} [gameType] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getMemberRanking(gameType?: string, options?: any): AxiosPromise<ApiResponseListMemberRankResponse> {
+            return localVarFp.getMemberRanking(gameType, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @summary 내 프로필 조회
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getMyProfileInfo(options?: any): AxiosPromise<ApiResponseMemberGetResponse> {
+        getMyProfileInfo(options?: any): AxiosPromise<ApiResponseAccountGetResponse> {
             return localVarFp.getMyProfileInfo(options).then((request) => request(axios, basePath));
         },
         /**
@@ -1318,6 +1442,18 @@ export class DefaultApi extends BaseAPI {
      */
     public enterGameRoom(roomId: number, gameRoomEnterRequest?: GameRoomEnterRequest, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).enterGameRoom(roomId, gameRoomEnterRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary 랭킹 조회
+     * @param {string} [gameType] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public getMemberRanking(gameType?: string, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).getMemberRanking(gameType, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/src/pages/GamePage/DisconnectModal.tsx
+++ b/src/pages/GamePage/DisconnectModal.tsx
@@ -1,0 +1,47 @@
+import * as AlertDialog from '@radix-ui/react-alert-dialog';
+
+interface DisconnectModalProps {
+  isOpen: boolean;
+  handleClickAction: () => void;
+  handleClickCancel: () => void;
+}
+const DisconnectModal = ({
+  isOpen,
+  handleClickAction,
+  handleClickCancel,
+}: DisconnectModalProps) => {
+  return (
+    <AlertDialog.Root open={isOpen}>
+      <AlertDialog.Trigger asChild></AlertDialog.Trigger>
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay className='fixed inset-0 w-[100vw] h-[100vh] bg-black/30 animate-[overlayShow_150ms_cubic-bezier(0.16,1,0.3,1)]' />
+        <AlertDialog.Content className='data-[state=open]:animate-contentShow fixed top-[50%] left-[50%] max-h-[85vh] w-[90vw] max-w-[500px] translate-x-[-50%] translate-y-[-50%] rounded-[6px] bg-white p-[25px] shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none'>
+          <AlertDialog.Title className='text-mauve12 m-0 text-[17px] font-medium'>
+            정말로 게임방을 나가시겠어요?
+          </AlertDialog.Title>
+          <AlertDialog.Description className='text-mauve11 mt-4 mb-5 text-[15px] leading-normal'>
+            게임방에서 나가면 다시 접속할 수 없어요.
+          </AlertDialog.Description>
+          <div className='flex justify-end gap-[25px]'>
+            <AlertDialog.Cancel asChild>
+              <button
+                onClick={handleClickCancel}
+                className='text-mauve11 bg-mauve4 hover:bg-mauve5 focus:shadow-mauve7 inline-flex h-[35px] items-center justify-center rounded-[4px] px-[15px] font-medium leading-none outline-none focus:shadow-[0_0_0_2px]'>
+                취소
+              </button>
+            </AlertDialog.Cancel>
+            <AlertDialog.Action asChild>
+              <button
+                onClick={handleClickAction}
+                className='text-red11 bg-red4 hover:bg-red5 focus:shadow-red7 inline-flex h-[35px] items-center justify-center rounded-[4px] px-[15px] font-medium leading-none outline-none focus:shadow-[0_0_0_2px]'>
+                네, 나갈래요
+              </button>
+            </AlertDialog.Action>
+          </div>
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  );
+};
+
+export default DisconnectModal;

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -36,7 +36,7 @@ const GamePage = () => {
       Authorization: `Bearer ${token}`,
     };
 
-    const ROOMID_TEST = 37; // 테스트용 RoomId ////////////////////////////////////
+    const ROOMID_TEST = 12; // 테스트용 RoomId ////////////////////////////////////
 
     const onConnected = () => {
       //TODO: roomId는 방입장 GET요청 응답값으로 사용
@@ -82,7 +82,7 @@ const GamePage = () => {
     [gameRoomRes]
   ); //모두 준비인상태에서 방장이 시작했다면 'START' type 이 옴 -> 참여자들 컴포넌트 전환 필요
 
-  if (!isSuccess) {
+  if (!isSuccess || !ws.current) {
     return <WsError />;
   }
   if (isPlaying) {

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -15,7 +15,7 @@ import GameWord from './GameWord/GameWord';
 const GamePage = () => {
   const navigate = useNavigate();
 
-  const [gameRoomInfo, setGameRoomInfo] = useState({} as I_GameRoomResponse);
+  const [gameRoomRes, setGameRoomRes] = useState({} as I_GameRoomResponse);
   const ws = useRef<CompatClient | null>(null);
 
   useEffect(() => {
@@ -36,7 +36,7 @@ const GamePage = () => {
       Authorization: `Bearer ${token}`,
     };
 
-    const ROOMID_TEST = 36; // 테스트용 RoomId ////////////////////////////////////
+    const ROOMID_TEST = 37; // 테스트용 RoomId ////////////////////////////////////
 
     const onConnected = () => {
       //TODO: roomId는 방입장 GET요청 응답값으로 사용
@@ -62,7 +62,7 @@ const GamePage = () => {
       // called when the client receives a STOMP message from the server
       // eslint-disable-next-line no-console
       console.log('onMessageReceived---', responsePublish);
-      setGameRoomInfo(responsePublish);
+      setGameRoomRes(responsePublish);
     };
 
     stompClient.connect(connectHeaders, () => {
@@ -72,14 +72,14 @@ const GamePage = () => {
     ws.current = stompClient;
   }, []);
 
-  const isSuccess = useMemo(() => !checkEmptyObj(gameRoomInfo), [gameRoomInfo]);
+  const isSuccess = useMemo(() => !checkEmptyObj(gameRoomRes), [gameRoomRes]);
   const [selectedMode, isPlaying] = useMemo(
-    () => [gameRoomInfo.roomInfo?.gameMode, gameRoomInfo.roomInfo?.isPlaying],
-    [gameRoomInfo.roomInfo]
+    () => [gameRoomRes.roomInfo?.gameMode, gameRoomRes.roomInfo?.isPlaying],
+    [gameRoomRes.roomInfo]
   );
   const didBossStart = useMemo(
-    () => gameRoomInfo.type === 'START',
-    [gameRoomInfo]
+    () => gameRoomRes.type === 'START',
+    [gameRoomRes]
   ); //모두 준비인상태에서 방장이 시작했다면 'START' type 이 옴 -> 참여자들 컴포넌트 전환 필요
 
   if (!isSuccess) {
@@ -100,7 +100,7 @@ const GamePage = () => {
         )
       ) : (
         <GameWaitingRoom
-          gameRoomInfo={gameRoomInfo}
+          gameRoomRes={gameRoomRes}
           ws={ws.current}
         />
       )}

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -25,8 +25,8 @@ const GamePage = () => {
     const { getItem, setItem } = storageFactory(localStorage);
     const guestLoginFn = async () => {
       const { data } = await guestLogin();
-      setItem('token', data.data.accessToken);
-      token = data.data.accessToken;
+      setItem('token', data.data?.accessToken);
+      token = data.data?.accessToken;
     };
     let token = getItem('token', '');
     if (!token) {
@@ -36,7 +36,7 @@ const GamePage = () => {
       Authorization: `Bearer ${token}`,
     };
 
-    const ROOMID_TEST = 12; // 테스트용 RoomId ////////////////////////////////////
+    const ROOMID_TEST = 19; // 테스트용 RoomId ////////////////////////////////////
 
     const onConnected = () => {
       //TODO: roomId는 방입장 GET요청 응답값으로 사용

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -1,5 +1,6 @@
 import { CompatClient, Stomp } from '@stomp/stompjs';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { guestLogin } from '@/apis/api';
 import { checkEmptyObj } from '@/utils/checkEmptyObj';
 import storageFactory from '@/utils/storageFactory';
@@ -12,6 +13,8 @@ import WsError from './GameWaitingRoom/WsError';
 import GameWord from './GameWord/GameWord';
 
 const GamePage = () => {
+  const navigate = useNavigate();
+
   const [gameRoomInfo, setGameRoomInfo] = useState({} as I_GameRoomResponse);
   const ws = useRef<CompatClient | null>(null);
 
@@ -33,7 +36,7 @@ const GamePage = () => {
       Authorization: `Bearer ${token}`,
     };
 
-    const ROOMID_TEST = 35; // 테스트용 RoomId ////////////////////////////////////
+    const ROOMID_TEST = 36; // 테스트용 RoomId ////////////////////////////////////
 
     const onConnected = () => {
       //TODO: roomId는 방입장 GET요청 응답값으로 사용
@@ -70,17 +73,20 @@ const GamePage = () => {
   }, []);
 
   const isSuccess = useMemo(() => !checkEmptyObj(gameRoomInfo), [gameRoomInfo]);
-  const selectedMode = useMemo(
-    () => gameRoomInfo.roomInfo?.gameMode,
-    [gameRoomInfo.roomInfo?.gameMode]
+  const [selectedMode, isPlaying] = useMemo(
+    () => [gameRoomInfo.roomInfo?.gameMode, gameRoomInfo.roomInfo?.isPlaying],
+    [gameRoomInfo.roomInfo]
   );
   const didBossStart = useMemo(
     () => gameRoomInfo.type === 'START',
     [gameRoomInfo]
-  ); //모두 준비인상태에서 방장이 시작했다면 'START' type 이 옴
+  ); //모두 준비인상태에서 방장이 시작했다면 'START' type 이 옴 -> 참여자들 컴포넌트 전환 필요
 
   if (!isSuccess) {
     return <WsError />;
+  }
+  if (isPlaying) {
+    navigate('/main');
   }
   return (
     <>

--- a/src/pages/GamePage/GameWaitingRoom/GameReadyAndStart.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameReadyAndStart.tsx
@@ -1,6 +1,18 @@
-const GameReadyAndStart = () => {
+import { CompatClient } from '@stomp/stompjs';
+import storageFactory from '@/utils/storageFactory';
+
+const GameReadyAndStart = ({ ws }: { ws: CompatClient }) => {
+  const { getItem } = storageFactory(localStorage);
+
+  const token = getItem('token', '');
+  const connectHeaders = {
+    Authorization: 'Bearer ' + token,
+  };
   return (
     <button
+      onClick={() => {
+        ws.send(`/to/game-room/10/ready`, connectHeaders, '입장~');
+      }}
       className={`w-[24.1rem] h-[10rem] flex justify-center items-center text-[2rem] bg-coral-50 hover:bg-coral-100 transition-all duration-300 shadow-md shadow-black/50 rounded-[2.5rem]`}>
       {/* TODO: 전부 준비 완료 되면 시작 버튼 색상 bg-coral-100으로 변경 */}
       시작

--- a/src/pages/GamePage/GameWaitingRoom/GameReadyAndStart.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameReadyAndStart.tsx
@@ -1,17 +1,18 @@
 import { CompatClient } from '@stomp/stompjs';
 import storageFactory from '@/utils/storageFactory';
 
-const GameReadyAndStart = ({ ws }: { ws: CompatClient | null }) => {
+const GameReadyAndStart = ({ ws }: { ws: CompatClient }) => {
   const { getItem } = storageFactory(localStorage);
 
   const token = getItem('token', '');
   const connectHeaders = {
     Authorization: 'Bearer ' + token,
   };
+  //TODO: 현재 방번호 zustand store에서
   return (
     <button
       onClick={() => {
-        ws && ws.send(`/to/game-room/10/ready`, connectHeaders, '입장~');
+        ws && ws.send(`/to/game-room/36/ready`, connectHeaders, '입장~');
       }}
       className={`w-[24.1rem] h-[10rem] flex justify-center items-center text-[2rem] bg-coral-50 hover:bg-coral-100 transition-all duration-300 shadow-md shadow-black/50 rounded-[2.5rem]`}>
       {/* TODO: 전부 준비 완료 되면 시작 버튼 색상 bg-coral-100으로 변경 */}

--- a/src/pages/GamePage/GameWaitingRoom/GameReadyAndStart.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameReadyAndStart.tsx
@@ -1,7 +1,7 @@
 import { CompatClient } from '@stomp/stompjs';
 import storageFactory from '@/utils/storageFactory';
 
-const GameReadyAndStart = ({ ws }: { ws: CompatClient }) => {
+const GameReadyAndStart = ({ ws }: { ws: CompatClient | null }) => {
   const { getItem } = storageFactory(localStorage);
 
   const token = getItem('token', '');
@@ -11,7 +11,7 @@ const GameReadyAndStart = ({ ws }: { ws: CompatClient }) => {
   return (
     <button
       onClick={() => {
-        ws.send(`/to/game-room/10/ready`, connectHeaders, '입장~');
+        ws && ws.send(`/to/game-room/10/ready`, connectHeaders, '입장~');
       }}
       className={`w-[24.1rem] h-[10rem] flex justify-center items-center text-[2rem] bg-coral-50 hover:bg-coral-100 transition-all duration-300 shadow-md shadow-black/50 rounded-[2.5rem]`}>
       {/* TODO: 전부 준비 완료 되면 시작 버튼 색상 bg-coral-100으로 변경 */}

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomInfo.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomInfo.tsx
@@ -1,24 +1,19 @@
 import { I_GameRoomResponse } from '@/ws/types/wsResType';
 import { GAME_TYPE } from '../constants';
 
-const GameRoomInfo = ({
-  gameRoomInfo,
-}: {
-  gameRoomInfo: I_GameRoomResponse;
-}) => {
+const GameRoomInfo = ({ gameRoomRes }: { gameRoomRes: I_GameRoomResponse }) => {
   return (
     <div className='w-[105rem] h-[7.1rem] text-[2rem] flex bg-beige-100 rounded-[2.5rem] shadow-md shadow-black/50 items-center '>
       <div className='flex justify-center items-center w-[25%] h-[70%] border-r border-solid border-black'>
-        No.{gameRoomInfo.roomId}
+        No.{gameRoomRes.roomId}
       </div>
       <div className='flex justify-center items-center w-[35%] h-[70%] border-r border-solid border-black'>
-        {gameRoomInfo.roomInfo?.title}
+        {gameRoomRes.roomInfo?.title}
       </div>
       <div className='flex justify-center items-center w-[20%] h-[70%] border-r border-solid border-black'>
-        {gameRoomInfo.roomInfo &&
-          GAME_TYPE.get(gameRoomInfo.roomInfo?.gameMode)}
+        {gameRoomRes.roomInfo && GAME_TYPE.get(gameRoomRes.roomInfo?.gameMode)}
       </div>
-      <div className='flex justify-center items-center w-[20%] h-[70%]'>{`${gameRoomInfo.allMembers?.length} / ${gameRoomInfo.roomInfo?.maxPlayer}`}</div>
+      <div className='flex justify-center items-center w-[20%] h-[70%]'>{`${gameRoomRes.allMembers?.length} / ${gameRoomRes.roomInfo?.maxPlayer}`}</div>
     </div>
   );
 };

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
@@ -11,15 +11,15 @@ const GameRoomUserItem = ({
   gameRoomUser: I_AllMember;
 }) => {
   const rank = 3; // TODO : 회원조회 쿼리 값으로 변경
-  const userId = 107; // TODO : 회원조회 쿼리 값으로 변경
+  const userId = 9; // TODO : 회원조회 쿼리 값으로 변경
 
   const { memberId, nickname, readyStatus: isReady } = gameRoomUser;
   const isAdminMe = useMemo(() => hostId === userId, [hostId]); //본인이 방장인지
 
   return (
     <div className='w-[25.8rem] h-[21.2rem] p-[1.6rem] pb-[4rem] relative flex flex-col bg-white shadow-md shadow-black/50 rounded-[2.5rem]'>
-      <div className='h-[3rem]'>
-        <button className='self-end'>
+      <div className='h-[3rem] self-end'>
+        <button>
           {isAdminMe && memberId !== userId && (
             <img
               src={close}

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
@@ -1,18 +1,34 @@
 import * as Avatar from '@radix-ui/react-avatar';
+import { useMemo } from 'react';
 import close from '@/assets/close.png';
 import { I_AllMember } from '@/ws/types/wsResType';
 
-const GameRoomUserItem = ({ nickname, readyStatus }: I_AllMember) => {
-  const rank = 3; // memberId로 회원조회!!
+const GameRoomUserItem = ({
+  hostId,
+  gameRoomUser,
+}: {
+  hostId: number | undefined;
+  gameRoomUser: I_AllMember;
+}) => {
+  const rank = 3; // TODO : 회원조회 쿼리 값으로 변경
+  const userId = 107; // TODO : 회원조회 쿼리 값으로 변경
+
+  const { memberId, nickname, readyStatus: isReady } = gameRoomUser;
+  const isAdminMe = useMemo(() => hostId === userId, [hostId]); //본인이 방장인지
+
   return (
     <div className='w-[25.8rem] h-[21.2rem] p-[1.6rem] pb-[4rem] relative flex flex-col bg-white shadow-md shadow-black/50 rounded-[2.5rem]'>
-      <button className='self-end'>
-        <img
-          src={close}
-          alt='강퇴'
-          className='w-[3rem]'
-        />
-      </button>
+      <div className='h-[3rem]'>
+        <button className='self-end'>
+          {isAdminMe && memberId !== userId && (
+            <img
+              src={close}
+              alt='강퇴'
+              className='w-[3rem]'
+            />
+          )}
+        </button>
+      </div>
       <div className='flex grow gap-[2rem]'>
         <Avatar.Root className='w-1/2 self-center'>
           <Avatar.Image
@@ -34,10 +50,11 @@ const GameRoomUserItem = ({ nickname, readyStatus }: I_AllMember) => {
           </div>
         </div>
       </div>
-      <div
-        className={`absolute w-[13rem] h-[4rem] rounded-[2rem_0_2.5rem] right-0 bottom-0 text-center leading-[4rem] font-[Giants-Inline] ${readyStatus && 'bg-green-100'}`}>
-        {readyStatus && '준비'}
-      </div>
+      {((isAdminMe && userId === memberId) || isReady) && (
+        <div className='absolute w-[13rem] h-[4rem] rounded-[2rem_0_2.5rem] right-0 bottom-0 text-center leading-[4rem] font-[Giants-Inline] bg-green-100'>
+          {isAdminMe && userId === memberId ? '방장' : isReady && '준비'}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
@@ -2,37 +2,41 @@ import * as Avatar from '@radix-ui/react-avatar';
 import close from '@/assets/close.png';
 import { I_AllMember } from '@/ws/types/wsResType';
 
-const GameRoomUserItem = ({ nickname }: I_AllMember) => {
+const GameRoomUserItem = ({ nickname, readyStatus }: I_AllMember) => {
   const rank = 3; // memberId로 회원조회!!
   return (
-    <div className='w-[25.8rem] h-[21.2rem] flex flex-col bg-white shadow-md shadow-black/50 rounded-[2.5rem]'>
-      <button className='self-end pt-[1.6rem] pr-[1.6rem] '>
+    <div className='w-[25.8rem] h-[21.2rem] p-[1.6rem] pb-[4rem] relative flex flex-col bg-white shadow-md shadow-black/50 rounded-[2.5rem]'>
+      <button className='self-end'>
         <img
           src={close}
           alt='강퇴'
           className='w-[3rem]'
         />
       </button>
-      <div className='px-[2rem] py-[1rem] flex gap-[2rem]'>
+      <div className='flex grow gap-[2rem]'>
         <Avatar.Root className='w-1/2 self-center'>
           <Avatar.Image
             className='size-[10rem] rounded-full'
             src={
-              'https://images.unsplash.com/photo-1492633423870-43d1cd2775eb?&w=128&h=128&dpr=2&q=80'
+              'https://images.unsplash.com/photo-1534278931827-8a259344abe7?q=80?&w=128&h=128&dpr=2&q=80'
             }
             alt='프로필 이미지'
           />
           {/*임시 이미지*/}
           <Avatar.Fallback delayMs={6000}>test</Avatar.Fallback>
         </Avatar.Root>
-        <div className='w-1/2 flex flex-col items-center justify-around text-center'>
-          <div className='w-[10rem] py-[0.4rem] bg-green-70 rounded-[2.5rem]'>
+        <div className='w-1/2 flex flex-col justify-evenly text-center'>
+          <div className='w-[10rem] py-[0.4rem] bg-green-70 rounded-[1rem]'>
             {nickname}
           </div>
-          <div className='w-[10rem] py-[0.4rem] bg-green-70 rounded-[2.5rem]'>
+          <div className='w-[5rem] py-[0.4rem] bg-green-70 rounded-[1rem] text-[1.4rem]'>
             {rank}등
           </div>
         </div>
+      </div>
+      <div
+        className={`absolute w-[13rem] h-[4rem] rounded-[2rem_0_2.5rem] right-0 bottom-0 text-center leading-[4rem] font-[Giants-Inline] ${readyStatus && 'bg-green-100'}`}>
+        {readyStatus && '준비'}
       </div>
     </div>
   );

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomUserList.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomUserList.tsx
@@ -3,8 +3,10 @@ import GameRoomUserItem from './GameRoomUserItem';
 
 const GameRoomUserList = ({
   gameRoomUserList,
+  hostId,
 }: {
   gameRoomUserList: I_AllMember[];
+  hostId: number | undefined;
 }) => {
   return (
     <>
@@ -13,7 +15,8 @@ const GameRoomUserList = ({
           gameRoomUserList.map((gameRoomUser) => (
             <GameRoomUserItem
               key={gameRoomUser.memberId}
-              {...gameRoomUser}
+              hostId={hostId}
+              gameRoomUser={gameRoomUser}
             />
           ))}
       </main>

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -13,7 +13,7 @@ const GameWaitingRoom = ({
   ws,
 }: {
   gameRoomInfo: I_GameRoomResponse;
-  ws: CompatClient;
+  ws: CompatClient | null;
 }) => {
   const { allMembers } = gameRoomInfo;
   return (

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -16,7 +16,7 @@ const GameWaitingRoom = ({
   ws,
 }: {
   gameRoomRes: I_GameRoomResponse;
-  ws: CompatClient | null;
+  ws: CompatClient;
 }) => {
   const navigate = useNavigate();
 
@@ -32,8 +32,13 @@ const GameWaitingRoom = ({
     <>
       <DisconnectModal
         isOpen={isAlert}
-        handleClickAction={() => navigate('/main')}
-        handleClickCancel={() => setIsAlert(false)}
+        handleClickAction={() => {
+          navigate('/main');
+          navigate(0);
+        }}
+        handleClickCancel={() => {
+          setIsAlert(false);
+        }}
       />
       <div className='w-full flex flex-col justify-center items-center gap-[3rem] select-none'>
         <header className='flex gap-[5rem]'>

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -1,3 +1,4 @@
+import { CompatClient } from '@stomp/stompjs';
 import Backward from '@/common/Backward/Backward';
 import { I_GameRoomResponse } from '@/ws/types/wsResType';
 import GameModeInfo from './GameModeInfo';
@@ -9,11 +10,12 @@ import GameRoomUserList from './GameRoomUserList';
 
 const GameWaitingRoom = ({
   gameRoomInfo,
+  ws,
 }: {
   gameRoomInfo: I_GameRoomResponse;
+  ws: CompatClient;
 }) => {
   const { allMembers } = gameRoomInfo;
-
   return (
     <div className='w-full flex flex-col justify-center items-center gap-[3rem] select-none'>
       <header className='flex gap-[5rem]'>
@@ -26,7 +28,7 @@ const GameWaitingRoom = ({
           <GameRoomSetting />
         </GameModeInfo>
         <GameRoomLinkInvitation />
-        <GameReadyAndStart />
+        <GameReadyAndStart ws={ws} />
       </footer>
     </div>
   );

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -9,20 +9,26 @@ import GameRoomSetting from './GameRoomSetting';
 import GameRoomUserList from './GameRoomUserList';
 
 const GameWaitingRoom = ({
-  gameRoomInfo,
+  gameRoomRes,
   ws,
 }: {
-  gameRoomInfo: I_GameRoomResponse;
+  gameRoomRes: I_GameRoomResponse;
   ws: CompatClient | null;
 }) => {
-  const { allMembers } = gameRoomInfo;
+  const { allMembers, roomInfo } = gameRoomRes;
+  // 각각 optional 이라 undefined 일수 있다고 추론됨 ..
   return (
     <div className='w-full flex flex-col justify-center items-center gap-[3rem] select-none'>
       <header className='flex gap-[5rem]'>
         <Backward />
-        <GameRoomInfo gameRoomInfo={gameRoomInfo} />
+        <GameRoomInfo gameRoomRes={gameRoomRes} />
       </header>
-      {allMembers && <GameRoomUserList gameRoomUserList={allMembers} />}
+      {allMembers && (
+        <GameRoomUserList
+          gameRoomUserList={allMembers}
+          hostId={roomInfo?.hostId}
+        />
+      )}
       <footer className='w-[114.8rem] flex gap-[5rem]'>
         <GameModeInfo>
           <GameRoomSetting />

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -1,6 +1,9 @@
 import { CompatClient } from '@stomp/stompjs';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Backward from '@/common/Backward/Backward';
 import { I_GameRoomResponse } from '@/ws/types/wsResType';
+import DisconnectModal from '../DisconnectModal';
 import GameModeInfo from './GameModeInfo';
 import GameReadyAndStart from './GameReadyAndStart';
 import GameRoomInfo from './GameRoomInfo';
@@ -15,28 +18,43 @@ const GameWaitingRoom = ({
   gameRoomRes: I_GameRoomResponse;
   ws: CompatClient | null;
 }) => {
+  const navigate = useNavigate();
+
   const { allMembers, roomInfo } = gameRoomRes;
   // 각각 optional 이라 undefined 일수 있다고 추론됨 ..
+
+  const [isAlert, setIsAlert] = useState(false);
+  const handleClickBackward = () => {
+    setIsAlert(true);
+  };
+
   return (
-    <div className='w-full flex flex-col justify-center items-center gap-[3rem] select-none'>
-      <header className='flex gap-[5rem]'>
-        <Backward />
-        <GameRoomInfo gameRoomRes={gameRoomRes} />
-      </header>
-      {allMembers && (
-        <GameRoomUserList
-          gameRoomUserList={allMembers}
-          hostId={roomInfo?.hostId}
-        />
-      )}
-      <footer className='w-[114.8rem] flex gap-[5rem]'>
-        <GameModeInfo>
-          <GameRoomSetting />
-        </GameModeInfo>
-        <GameRoomLinkInvitation />
-        <GameReadyAndStart ws={ws} />
-      </footer>
-    </div>
+    <>
+      <DisconnectModal
+        isOpen={isAlert}
+        handleClickAction={() => navigate('/main')}
+        handleClickCancel={() => setIsAlert(false)}
+      />
+      <div className='w-full flex flex-col justify-center items-center gap-[3rem] select-none'>
+        <header className='flex gap-[5rem]'>
+          <Backward handleClickBackward={handleClickBackward} />
+          <GameRoomInfo gameRoomRes={gameRoomRes} />
+        </header>
+        {allMembers && (
+          <GameRoomUserList
+            gameRoomUserList={allMembers}
+            hostId={roomInfo?.hostId}
+          />
+        )}
+        <footer className='w-[114.8rem] flex gap-[5rem]'>
+          <GameModeInfo>
+            <GameRoomSetting />
+          </GameModeInfo>
+          <GameRoomLinkInvitation />
+          <GameReadyAndStart ws={ws} />
+        </footer>
+      </div>
+    </>
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2127,6 +2127,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-alert-dialog@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "@radix-ui/react-alert-dialog@npm:1.0.5"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+    "@radix-ui/primitive": "npm:1.0.1"
+    "@radix-ui/react-compose-refs": "npm:1.0.1"
+    "@radix-ui/react-context": "npm:1.0.1"
+    "@radix-ui/react-dialog": "npm:1.0.5"
+    "@radix-ui/react-primitive": "npm:1.0.3"
+    "@radix-ui/react-slot": "npm:1.0.2"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/73854a1011b07a50261a12ce33c4b9d6585603e731a2ceffc7a4d2b8c795631716fda8b8006a813648e247d17abbaf290a419a935ae4cd70c83c3c70a34ce9f4
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-avatar@npm:^1.0.4":
   version: 1.0.4
   resolution: "@radix-ui/react-avatar@npm:1.0.4"
@@ -2203,7 +2228,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-dialog@npm:^1.0.5":
+"@radix-ui/react-dialog@npm:1.0.5, @radix-ui/react-dialog@npm:^1.0.5":
   version: 1.0.5
   resolution: "@radix-ui/react-dialog@npm:1.0.5"
   dependencies:
@@ -10253,6 +10278,7 @@ __metadata:
   resolution: "team-e2i4-tikitaza-fe@workspace:."
   dependencies:
     "@openapitools/openapi-generator-cli": "npm:^2.9.0"
+    "@radix-ui/react-alert-dialog": "npm:^1.0.5"
     "@radix-ui/react-avatar": "npm:^1.0.4"
     "@radix-ui/react-dialog": "npm:^1.0.5"
     "@radix-ui/react-form": "npm:^0.0.3"


### PR DESCRIPTION
## 📋 Issue Number
close #

## 💻 구현 내용

- 유저의 상태(방장 유무, 준비 유무)를 웹소켓서버로 전송, 응답 합니다
- 방 나가기 시 alert 모달 확인 후 화면 이동합니다

## 📷 Screenshots


https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/81412212/13b7021a-03cd-42f7-8939-12aeed3b6b60


https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/81412212/c7d5d818-06ed-4a27-89c1-02f03ca8e623


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
* 2c64d84e8fe544eb7d326f9b7b80e8f4b8bfd496 StompClienet를 useRef로 두어서 초기값인 null값이 허용되더라구요, 프롭스로 넘길때마다 타입을 `| null` 처리해야되는데, 다른 방법이 있을까요? 매번 if (ws) { ..} 처럼 가드를 하는게 더 번잡해진다고 느껴서 이렇게 처리했습니다.
* 뒤로가기(< Backward >)로 인게임을 나갈 경우에도 /main으로 라우팅을 하는데, useNavigate를 사용하기 때문에 새로고침이 발생하지 않아서 웹소켓 연결이 끊기지 않았습니다. 그래서 강제로 `window.location.reload()`를 사용했는데, 다른 방법이 있을까요?   useEffect 클린업 함수도 사용해보았는데, 접속자 모두가 연결이 끊겨서 방이 사라지는 문제가 생겼습니다. 같이 확인해봐도 좋겠네욥

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->

---
TODO
- [ ] 유저의 로그인(소셜,게스트 공통)시 응답받는 UserId가 저장된 react query에 접근해서 userId로 사용합니다