### PR TITLE
[Feat] 방 입장 기능 구현

### DIFF
--- a/src/hooks/useEnterGameRoom.ts
+++ b/src/hooks/useEnterGameRoom.ts
@@ -1,5 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
-import { AxiosResponse } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
+import { ErrorResponse } from 'react-router-dom';
 import { enterGameRoom } from '@/apis/api';
 import { ApiResponseGameRoomEnterResponse } from '@/generated';
 
@@ -15,7 +16,7 @@ export interface I_UseEnterGameRoomMutation {
 const useEnterGameRoom = ({ onSuccess }: UseEnterGameRoomProps) => {
   return useMutation<
     AxiosResponse<ApiResponseGameRoomEnterResponse>,
-    Error,
+    Error | AxiosError<ErrorResponse>,
     I_UseEnterGameRoomMutation
   >({
     mutationFn: ({ roomId, password }: I_UseEnterGameRoomMutation) =>
@@ -23,6 +24,20 @@ const useEnterGameRoom = ({ onSuccess }: UseEnterGameRoomProps) => {
     mutationKey: ['enterGameRoom'],
     onSuccess: () => {
       onSuccess?.();
+    },
+    onError: (e) => alert(e),
+    throwOnError: (e) => {
+      if (!(e instanceof AxiosError)) {
+        return true;
+      }
+      if (
+        e.response?.status === 400 ||
+        e.response?.status === 404 ||
+        e.response?.status === 409
+      ) {
+        return false;
+      }
+      return true;
     },
   });
 };

--- a/src/hooks/useEnterGameRoom.ts
+++ b/src/hooks/useEnterGameRoom.ts
@@ -1,13 +1,25 @@
 import { useMutation } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
 import { enterGameRoom } from '@/apis/api';
+import { ApiResponseGameRoomEnterResponse } from '@/generated';
 
 interface UseEnterGameRoomProps {
   onSuccess?: () => void;
 }
 
+export interface I_UseEnterGameRoomMutation {
+  roomId: number;
+  password?: string;
+}
+
 const useEnterGameRoom = ({ onSuccess }: UseEnterGameRoomProps) => {
-  return useMutation({
-    mutationFn: enterGameRoom,
+  return useMutation<
+    AxiosResponse<ApiResponseGameRoomEnterResponse>,
+    Error,
+    I_UseEnterGameRoomMutation
+  >({
+    mutationFn: ({ roomId, password }: I_UseEnterGameRoomMutation) =>
+      enterGameRoom(roomId, { password }),
     mutationKey: ['enterGameRoom'],
     onSuccess: () => {
       onSuccess?.();

--- a/src/hooks/useEnterGameRoom.ts
+++ b/src/hooks/useEnterGameRoom.ts
@@ -1,11 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
-import { ErrorResponse } from 'react-router-dom';
 import { enterGameRoom } from '@/apis/api';
-import { ApiResponseGameRoomEnterResponse } from '@/generated';
+import { ApiResponseGameRoomEnterResponse, ErrorResponse } from '@/generated';
 
 interface UseEnterGameRoomProps {
   onSuccess?: () => void;
+  onError?: (e: AxiosError<ErrorResponse>) => void;
 }
 
 export interface I_UseEnterGameRoomMutation {
@@ -13,7 +13,7 @@ export interface I_UseEnterGameRoomMutation {
   password?: string;
 }
 
-const useEnterGameRoom = ({ onSuccess }: UseEnterGameRoomProps) => {
+const useEnterGameRoom = ({ onSuccess, onError }: UseEnterGameRoomProps) => {
   return useMutation<
     AxiosResponse<ApiResponseGameRoomEnterResponse>,
     Error | AxiosError<ErrorResponse>,
@@ -25,7 +25,11 @@ const useEnterGameRoom = ({ onSuccess }: UseEnterGameRoomProps) => {
     onSuccess: () => {
       onSuccess?.();
     },
-    onError: (e) => alert(e),
+    onError: (e) => {
+      if (e instanceof AxiosError) {
+        onError?.(e);
+      }
+    },
     throwOnError: (e) => {
       if (!(e instanceof AxiosError)) {
         return true;

--- a/src/hooks/useEnterGameRoom.ts
+++ b/src/hooks/useEnterGameRoom.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query';
+import { enterGameRoom } from '@/apis/api';
+
+interface UseEnterGameRoomProps {
+  onSuccess?: () => void;
+}
+
+const useEnterGameRoom = ({ onSuccess }: UseEnterGameRoomProps) => {
+  return useMutation({
+    mutationFn: enterGameRoom,
+    mutationKey: ['enterGameRoom'],
+    onSuccess: () => {
+      onSuccess?.();
+    },
+  });
+};
+
+export default useEnterGameRoom;

--- a/src/pages/MainPage/CreateRoom/CreateRoomForm.tsx
+++ b/src/pages/MainPage/CreateRoom/CreateRoomForm.tsx
@@ -1,6 +1,7 @@
 import * as Form from '@radix-ui/react-form';
 import { Dispatch, SetStateAction, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 import { GameRoomCreateRequest } from '@/generated';
 import useCreateGameRoom from '@/hooks/useCreateGameRoom';
 import useRoomIdStore from '@/store/useRoomIdStore';
@@ -31,6 +32,8 @@ const CreateRoomForm = ({ setIsOpen }: CreateRoomFormProps) => {
 
   const { setRoomId } = useRoomIdStore();
 
+  const navigate = useNavigate();
+
   const { mutate: mutateCreateGameRoom } = useCreateGameRoom({
     onSuccess: (e) => {
       if (!e.data.data) {
@@ -39,6 +42,7 @@ const CreateRoomForm = ({ setIsOpen }: CreateRoomFormProps) => {
       alert('방 생성 성공');
       setRoomId(e.data.data.roomId);
       setIsOpen(false);
+      navigate('/game');
     },
   });
 

--- a/src/pages/MainPage/EnterRoomErrorFallback.tsx
+++ b/src/pages/MainPage/EnterRoomErrorFallback.tsx
@@ -6,8 +6,8 @@ const EnterRoomErrorFallback = ({
 }: FallbackProps) => {
   return (
     <div className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 row-start-2 col-start-1 col-span-2'>
-      오류났습메
-      <span>{error}</span>
+      {error.response.data.errorCode}|{error.response.data.errorMessage}|
+      {error.response.data?.validation?.title}|
       <button onClick={resetErrorBoundary}>오류초기화</button>
     </div>
   );

--- a/src/pages/MainPage/EnterRoomErrorFallback.tsx
+++ b/src/pages/MainPage/EnterRoomErrorFallback.tsx
@@ -1,0 +1,16 @@
+import { FallbackProps } from 'react-error-boundary';
+
+const EnterRoomErrorFallback = ({
+  error,
+  resetErrorBoundary,
+}: FallbackProps) => {
+  return (
+    <div className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 row-start-2 col-start-1 col-span-2'>
+      오류났습메
+      <span>{error}</span>
+      <button onClick={resetErrorBoundary}>오류초기화</button>
+    </div>
+  );
+};
+
+export default EnterRoomErrorFallback;

--- a/src/pages/MainPage/GameRoomList.tsx
+++ b/src/pages/MainPage/GameRoomList.tsx
@@ -1,6 +1,8 @@
 import { Fragment, useState } from 'react';
 import Divider from '@/common/Divider/Divider';
-import useEnterGameRoom from '@/hooks/useEnterGameRoom';
+import useEnterGameRoom, {
+  I_UseEnterGameRoomMutation,
+} from '@/hooks/useEnterGameRoom';
 import { I_ChangeGameRoomData } from '@/hooks/useSSE';
 import GameRoomListItem from './GameRoonListItem';
 import PrivateRoomModal from './PrivateRoomModal';
@@ -10,8 +12,11 @@ const GAME_ROOM_LIST_CATEGORY = ['방 번호', '방 제목', '게임 모드', '�
 const GameRoomList = ({ data }: { data: I_ChangeGameRoomData[] }) => {
   const { mutate: mutateEnterGameRoom } = useEnterGameRoom({});
   const [isOpen, setIsOpen] = useState(false);
-  const handleEnterGameRoom = (roomId: number) => {
-    mutateEnterGameRoom(roomId);
+  const handleEnterGameRoom = ({
+    roomId,
+    password,
+  }: I_UseEnterGameRoomMutation) => {
+    mutateEnterGameRoom({ roomId, password });
   };
   return (
     <article className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 row-start-2 col-start-1 col-span-2'>

--- a/src/pages/MainPage/GameRoomList.tsx
+++ b/src/pages/MainPage/GameRoomList.tsx
@@ -1,6 +1,5 @@
 import { Fragment, useState } from 'react';
 import Divider from '@/common/Divider/Divider';
-import useEnterGameRoom from '@/hooks/useEnterGameRoom';
 import { I_ChangeGameRoomData } from '@/hooks/useSSE';
 import GameRoomListItem from './GameRoonListItem';
 import PrivateRoomModal from './PrivateRoomModal';
@@ -8,7 +7,6 @@ import PrivateRoomModal from './PrivateRoomModal';
 const GAME_ROOM_LIST_CATEGORY = ['방 번호', '방 제목', '게임 모드', '인원수'];
 
 const GameRoomList = ({ data }: { data: I_ChangeGameRoomData[] }) => {
-  const { mutate: mutateEnterGameRoom } = useEnterGameRoom({});
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -46,7 +44,6 @@ const GameRoomList = ({ data }: { data: I_ChangeGameRoomData[] }) => {
                 <GameRoomListItem
                   key={roomData.id}
                   {...roomData}
-                  handleGameRoomItemClick={mutateEnterGameRoom}
                 />
               )
             )}

--- a/src/pages/MainPage/GameRoomList.tsx
+++ b/src/pages/MainPage/GameRoomList.tsx
@@ -1,8 +1,6 @@
 import { Fragment, useState } from 'react';
 import Divider from '@/common/Divider/Divider';
-import useEnterGameRoom, {
-  I_UseEnterGameRoomMutation,
-} from '@/hooks/useEnterGameRoom';
+import useEnterGameRoom from '@/hooks/useEnterGameRoom';
 import { I_ChangeGameRoomData } from '@/hooks/useSSE';
 import GameRoomListItem from './GameRoonListItem';
 import PrivateRoomModal from './PrivateRoomModal';
@@ -12,12 +10,6 @@ const GAME_ROOM_LIST_CATEGORY = ['방 번호', '방 제목', '게임 모드', '�
 const GameRoomList = ({ data }: { data: I_ChangeGameRoomData[] }) => {
   const { mutate: mutateEnterGameRoom } = useEnterGameRoom({});
   const [isOpen, setIsOpen] = useState(false);
-  const handleEnterGameRoom = ({
-    roomId,
-    password,
-  }: I_UseEnterGameRoomMutation) => {
-    mutateEnterGameRoom({ roomId, password });
-  };
 
   return (
     <article className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 row-start-2 col-start-1 col-span-2'>
@@ -45,7 +37,6 @@ const GameRoomList = ({ data }: { data: I_ChangeGameRoomData[] }) => {
               roomData.isPrivate ? (
                 <PrivateRoomModal
                   key={roomData.id}
-                  handlePasswordSubmit={handleEnterGameRoom}
                   setIsOpen={setIsOpen}
                   roomId={roomData.id}
                   isOpen={isOpen}>
@@ -55,7 +46,7 @@ const GameRoomList = ({ data }: { data: I_ChangeGameRoomData[] }) => {
                 <GameRoomListItem
                   key={roomData.id}
                   {...roomData}
-                  handleGameRoomItemClick={handleEnterGameRoom}
+                  handleGameRoomItemClick={mutateEnterGameRoom}
                 />
               )
             )}

--- a/src/pages/MainPage/GameRoomList.tsx
+++ b/src/pages/MainPage/GameRoomList.tsx
@@ -18,6 +18,7 @@ const GameRoomList = ({ data }: { data: I_ChangeGameRoomData[] }) => {
   }: I_UseEnterGameRoomMutation) => {
     mutateEnterGameRoom({ roomId, password });
   };
+
   return (
     <article className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 row-start-2 col-start-1 col-span-2'>
       <ul className='flex flex-col items-center px-[1.5rem]'>

--- a/src/pages/MainPage/GameRoomList.tsx
+++ b/src/pages/MainPage/GameRoomList.tsx
@@ -1,5 +1,6 @@
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import Divider from '@/common/Divider/Divider';
+import useEnterGameRoom from '@/hooks/useEnterGameRoom';
 import { I_ChangeGameRoomData } from '@/hooks/useSSE';
 import GameRoomListItem from './GameRoonListItem';
 import PrivateRoomModal from './PrivateRoomModal';
@@ -7,6 +8,11 @@ import PrivateRoomModal from './PrivateRoomModal';
 const GAME_ROOM_LIST_CATEGORY = ['방 번호', '방 제목', '게임 모드', '인원수'];
 
 const GameRoomList = ({ data }: { data: I_ChangeGameRoomData[] }) => {
+  const { mutate: mutateEnterGameRoom } = useEnterGameRoom({});
+  const [isOpen, setIsOpen] = useState(false);
+  const handleEnterGameRoom = (roomId: number) => {
+    mutateEnterGameRoom(roomId);
+  };
   return (
     <article className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 row-start-2 col-start-1 col-span-2'>
       <ul className='flex flex-col items-center px-[1.5rem]'>
@@ -31,13 +37,19 @@ const GameRoomList = ({ data }: { data: I_ChangeGameRoomData[] }) => {
           <ul className='w-full flex flex-col gap-[1rem] max-h-[60rem] overflow-y-auto scrollbar-hide pt-[1rem]'>
             {data.map((roomData) =>
               roomData.isPrivate ? (
-                <PrivateRoomModal key={roomData.id}>
+                <PrivateRoomModal
+                  key={roomData.id}
+                  handlePasswordSubmit={handleEnterGameRoom}
+                  setIsOpen={setIsOpen}
+                  roomId={roomData.id}
+                  isOpen={isOpen}>
                   <GameRoomListItem {...roomData} />
                 </PrivateRoomModal>
               ) : (
                 <GameRoomListItem
                   key={roomData.id}
                   {...roomData}
+                  handleGameRoomItemClick={handleEnterGameRoom}
                 />
               )
             )}

--- a/src/pages/MainPage/GameRoonListItem.tsx
+++ b/src/pages/MainPage/GameRoonListItem.tsx
@@ -1,5 +1,6 @@
 import { LockClosedIcon } from '@radix-ui/react-icons';
 import Divider from '@/common/Divider/Divider';
+import { I_UseEnterGameRoomMutation } from '@/hooks/useEnterGameRoom';
 import { I_ChangeGameRoomData } from '@/hooks/useSSE';
 
 const MODE_TYPE = {
@@ -9,7 +10,10 @@ const MODE_TYPE = {
 };
 
 interface GameRoomListItemProps extends I_ChangeGameRoomData {
-  handleGameRoomItemClick?: (roomId: number) => void;
+  handleGameRoomItemClick?: ({
+    roomId,
+    password,
+  }: I_UseEnterGameRoomMutation) => void;
 }
 
 const GameRoomListItem = ({
@@ -20,12 +24,15 @@ const GameRoomListItem = ({
   currentPlayer,
   isPlaying,
   isPrivate,
+  handleGameRoomItemClick,
 }: GameRoomListItemProps) => {
   if (isPlaying) {
     return;
   }
   return (
-    <li className='h-[5rem] flex items-center shrink-0 w-full py-[1rem] bg-gray-10 hover:bg-coral-50 cursor-pointer'>
+    <li
+      onClick={() => handleGameRoomItemClick?.({ roomId: id })}
+      className='h-[5rem] flex items-center shrink-0 w-full py-[1rem] bg-gray-10 hover:bg-coral-50 cursor-pointer'>
       <span className='text-center truncate flex-1'>{`No.${id}`}</span>
       <Divider
         orientation='vertical'

--- a/src/pages/MainPage/GameRoonListItem.tsx
+++ b/src/pages/MainPage/GameRoonListItem.tsx
@@ -1,4 +1,5 @@
 import { LockClosedIcon } from '@radix-ui/react-icons';
+import { useNavigate } from 'react-router-dom';
 import Divider from '@/common/Divider/Divider';
 import useEnterGameRoom from '@/hooks/useEnterGameRoom';
 import { I_ChangeGameRoomData } from '@/hooks/useSSE';
@@ -20,10 +21,12 @@ const GameRoomListItem = ({
   isPrivate,
 }: I_ChangeGameRoomData) => {
   const { setRoomId } = useRoomIdStore();
+  const navigate = useNavigate();
 
   const { mutate: mutateEnterGameRoom } = useEnterGameRoom({
     onSuccess: () => {
       setRoomId(id);
+      navigate('/game');
     },
   });
 

--- a/src/pages/MainPage/GameRoonListItem.tsx
+++ b/src/pages/MainPage/GameRoonListItem.tsx
@@ -1,20 +1,14 @@
 import { LockClosedIcon } from '@radix-ui/react-icons';
 import Divider from '@/common/Divider/Divider';
-import { I_UseEnterGameRoomMutation } from '@/hooks/useEnterGameRoom';
+import useEnterGameRoom from '@/hooks/useEnterGameRoom';
 import { I_ChangeGameRoomData } from '@/hooks/useSSE';
+import useRoomIdStore from '@/store/useRoomIdStore';
 
 const MODE_TYPE = {
   WORD: '짧은 단어',
   SENTENCE: '문장',
   CODE: '코드',
 };
-
-interface GameRoomListItemProps extends I_ChangeGameRoomData {
-  handleGameRoomItemClick?: ({
-    roomId,
-    password,
-  }: I_UseEnterGameRoomMutation) => void;
-}
 
 const GameRoomListItem = ({
   id,
@@ -24,14 +18,22 @@ const GameRoomListItem = ({
   currentPlayer,
   isPlaying,
   isPrivate,
-  handleGameRoomItemClick,
-}: GameRoomListItemProps) => {
+}: I_ChangeGameRoomData) => {
+  const { setRoomId } = useRoomIdStore();
+
+  const { mutate: mutateEnterGameRoom } = useEnterGameRoom({
+    onSuccess: () => {
+      setRoomId(id);
+    },
+  });
+
   if (isPlaying) {
     return;
   }
+
   return (
     <li
-      onClick={() => handleGameRoomItemClick?.({ roomId: id })}
+      onClick={() => mutateEnterGameRoom({ roomId: id })}
       className='h-[5rem] flex items-center shrink-0 w-full py-[1rem] bg-gray-10 hover:bg-coral-50 cursor-pointer'>
       <span className='text-center truncate flex-1'>{`No.${id}`}</span>
       <Divider

--- a/src/pages/MainPage/GameRoonListItem.tsx
+++ b/src/pages/MainPage/GameRoonListItem.tsx
@@ -8,6 +8,10 @@ const MODE_TYPE = {
   CODE: '코드',
 };
 
+interface GameRoomListItemProps extends I_ChangeGameRoomData {
+  handleGameRoomItemClick?: (roomId: number) => void;
+}
+
 const GameRoomListItem = ({
   id,
   title,
@@ -16,7 +20,7 @@ const GameRoomListItem = ({
   currentPlayer,
   isPlaying,
   isPrivate,
-}: I_ChangeGameRoomData) => {
+}: GameRoomListItemProps) => {
   if (isPlaying) {
     return;
   }

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,4 +1,6 @@
+import { ErrorBoundary } from 'react-error-boundary';
 import CreateRoomModal from './CreateRoom/CreateRoomModal';
+import EnterRoomErrorFallback from './EnterRoomErrorFallback';
 import GameRoomList from './GameRoomList';
 import SSEErrorBoundary from './SSEErrorBoundary';
 import SSEFallBack from './SSEFallBack';
@@ -23,7 +25,11 @@ const MainPage = () => {
           </article>
         </CreateRoomModal>
         <SSEErrorBoundary fallback={(error) => <SSEFallBack error={error} />}>
-          {(data) => <GameRoomList data={data} />}
+          {(data) => (
+            <ErrorBoundary fallbackRender={EnterRoomErrorFallback}>
+              <GameRoomList data={data} />
+            </ErrorBoundary>
+          )}
         </SSEErrorBoundary>
       </section>
     </main>

--- a/src/pages/MainPage/PrivateRoomModal.tsx
+++ b/src/pages/MainPage/PrivateRoomModal.tsx
@@ -1,17 +1,25 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { Cross2Icon, PaperPlaneIcon } from '@radix-ui/react-icons';
-import { ComponentProps, ReactNode, useState } from 'react';
+import { ComponentProps, Dispatch, ReactNode, SetStateAction } from 'react';
 import Input from '@/common/Input/Input';
 
 interface PrivateRoomModalProps {
   children: ReactNode;
   className?: ComponentProps<'div'>['className'];
+  handlePasswordSubmit: (roomId: number) => void;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  isOpen: boolean;
+  roomId: number;
 }
 
-const wait = () => new Promise((resolve) => setTimeout(resolve, 2000));
-
-const PrivateRoomModal = ({ children, className }: PrivateRoomModalProps) => {
-  const [isOpen, setIsOpen] = useState(false);
+const PrivateRoomModal = ({
+  children,
+  className,
+  handlePasswordSubmit,
+  isOpen,
+  setIsOpen,
+  roomId,
+}: PrivateRoomModalProps) => {
   return (
     <Dialog.Root
       open={isOpen}
@@ -30,7 +38,7 @@ const PrivateRoomModal = ({ children, className }: PrivateRoomModalProps) => {
             className='flex gap-[1rem] items-center'
             onSubmit={(e) => {
               e.preventDefault();
-              wait().then(() => setIsOpen(false));
+              handlePasswordSubmit(roomId);
             }}>
             <Input whSize='w-[20rem] h-[3rem]' />
             <button

--- a/src/pages/MainPage/PrivateRoomModal.tsx
+++ b/src/pages/MainPage/PrivateRoomModal.tsx
@@ -4,6 +4,7 @@ import { Cross2Icon, PaperPlaneIcon } from '@radix-ui/react-icons';
 import { AxiosError } from 'axios';
 import { ComponentProps, Dispatch, ReactNode, SetStateAction } from 'react';
 import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 import { ErrorResponse } from '@/generated';
 import useEnterGameRoom from '@/hooks/useEnterGameRoom';
 import useRoomIdStore from '@/store/useRoomIdStore';
@@ -33,10 +34,13 @@ const PrivateRoomModal = ({
 
   const { setRoomId } = useRoomIdStore();
 
+  const navigate = useNavigate();
+
   const { mutate: mutateEnterGameRoom } = useEnterGameRoom({
     onSuccess: () => {
       setRoomId(roomId);
       setIsOpen(false);
+      navigate('/game');
     },
     onError: (e: AxiosError<ErrorResponse>) => {
       setError('password', { message: e.response?.data.errorMessage });

--- a/src/pages/MainPage/PrivateRoomModal.tsx
+++ b/src/pages/MainPage/PrivateRoomModal.tsx
@@ -6,6 +6,7 @@ import { ComponentProps, Dispatch, ReactNode, SetStateAction } from 'react';
 import { useForm } from 'react-hook-form';
 import { ErrorResponse } from '@/generated';
 import useEnterGameRoom from '@/hooks/useEnterGameRoom';
+import useRoomIdStore from '@/store/useRoomIdStore';
 
 interface PrivateRoomModalProps {
   children: ReactNode;
@@ -30,11 +31,18 @@ const PrivateRoomModal = ({
     getValues,
   } = useForm<{ password: string }>();
 
-  const { mutate: mutateEnterGameRoom, isSuccess } = useEnterGameRoom({
+  const { setRoomId } = useRoomIdStore();
+
+  const { mutate: mutateEnterGameRoom } = useEnterGameRoom({
+    onSuccess: () => {
+      setRoomId(roomId);
+      setIsOpen(false);
+    },
     onError: (e: AxiosError<ErrorResponse>) => {
       setError('password', { message: e.response?.data.errorMessage });
     },
   });
+
   return (
     <Dialog.Root
       open={isOpen}
@@ -53,7 +61,6 @@ const PrivateRoomModal = ({
             className='flex gap-[1rem] items-center'
             onSubmit={handleSubmit(() => {
               mutateEnterGameRoom({ roomId, password: getValues('password') });
-              isSuccess && setIsOpen(false);
             })}>
             <Form.Field name='password'>
               <Form.Control

--- a/src/pages/MainPage/PrivateRoomModal.tsx
+++ b/src/pages/MainPage/PrivateRoomModal.tsx
@@ -2,11 +2,15 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { Cross2Icon, PaperPlaneIcon } from '@radix-ui/react-icons';
 import { ComponentProps, Dispatch, ReactNode, SetStateAction } from 'react';
 import Input from '@/common/Input/Input';
+import { I_UseEnterGameRoomMutation } from '@/hooks/useEnterGameRoom';
 
 interface PrivateRoomModalProps {
   children: ReactNode;
   className?: ComponentProps<'div'>['className'];
-  handlePasswordSubmit: (roomId: number) => void;
+  handlePasswordSubmit?: ({
+    roomId,
+    password,
+  }: I_UseEnterGameRoomMutation) => void;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   isOpen: boolean;
   roomId: number;
@@ -38,7 +42,7 @@ const PrivateRoomModal = ({
             className='flex gap-[1rem] items-center'
             onSubmit={(e) => {
               e.preventDefault();
-              handlePasswordSubmit(roomId);
+              handlePasswordSubmit?.({ roomId });
             }}>
             <Input whSize='w-[20rem] h-[3rem]' />
             <button

--- a/src/store/useRoomIdStore.ts
+++ b/src/store/useRoomIdStore.ts
@@ -7,9 +7,7 @@ interface I_RoomIdState {
 
 const useRoomIdStore = create<I_RoomIdState>((set) => ({
   roomId: null,
-  setRoomId: (roomId: number) => {
-    set(() => ({ roomId }));
-  },
+  setRoomId: (roomId: number) => set({ roomId }),
 }));
 
 export default useRoomIdStore;


### PR DESCRIPTION
## 📋 Issue Number
close #58 

## 💻 구현 내용

- 방입장하는 기능을 구현했습니다.
- 비공개방, 공개방 나눠서 구현했습니다.
- 비밀번호가 일치하지 않을시 입장 막아뒀습니다.
- PrivateModal에 react-hook-form을 적용해두었습니다.

## 📷 Screenshots
![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/c0858feb-f224-44eb-a762-7f211224d28d)

## 🤔 고민사항
- 게임 입장 플로우를 보기위하여 리팩토링을 전혀 하지 못한상태입니다. 양해부탁드립니다..!!
- GameRoomList, PrivateModal, GameRoomListItem이 강하게 결합되어있습니다. 이를 어떻게 뗄지...감이안옵니다...
1. PrviateModal과 GameRoomListItem은 GameRoomList의 자식입니다
2. 둘 다 mutation을 씁니다. but, onSuccess시 로직이 약간 다릅니다. => 프롭스로 내려주어야 할까요?
3. 둘 다 zustand Store를 업데이트합니다. => 프롭스로 내려주어야할까요?

실제 상태와 연관이 있으니, props로 전달해도 무방할까요?

컴포넌트 분리도 걱정입니다..ㅎㅎ

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
