### PR TITLE
[Feat] 라우팅별 인증 기능

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import './index.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Outlet } from 'react-router-dom';
+import AuthRoute from './common/AuthRoute/AuthRoute';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -14,7 +16,11 @@ const queryClient = new QueryClient({
 export const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
-      <Outlet />
+      <ErrorBoundary fallback={<div>연유를 모르는 에러</div>}>
+        <AuthRoute>
+          <Outlet />
+        </AuthRoute>
+      </ErrorBoundary>
     </QueryClientProvider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,6 @@
 import './index.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ErrorBoundary } from 'react-error-boundary';
 import { Outlet } from 'react-router-dom';
-import AuthRoute from './common/AuthRoute/AuthRoute';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -16,11 +14,7 @@ const queryClient = new QueryClient({
 export const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
-      <ErrorBoundary fallback={<div>연유를 모르는 에러</div>}>
-        <AuthRoute>
-          <Outlet />
-        </AuthRoute>
-      </ErrorBoundary>
+      <Outlet />
     </QueryClientProvider>
   );
 };

--- a/src/common/AuthRoute/AuthRoute.tsx
+++ b/src/common/AuthRoute/AuthRoute.tsx
@@ -1,31 +1,22 @@
-import { AxiosError } from 'axios';
-import { ReactNode } from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useAuthCheck } from '@/hooks/useAuth';
 
-const AuthRoute = ({ children }: { children: ReactNode }) => {
+const AuthRoute = () => {
   const { pathname } = useLocation();
-  const { data, isSuccess, isLoading, error } = useAuthCheck();
-
+  const { data, isSuccess, isLoading } = useAuthCheck();
   if (isLoading) {
-    return;
+    return <div>로딩중~</div>;
   }
-
-  if (error instanceof AxiosError) {
-    if (error.response?.data.errorCode === 'sec-401/01') {
-      if (pathname === '/login' || pathname === '/') {
-        alert('로그인한 유저는 들어갈 수 없는 페이지 입니다');
-        return <Navigate to={'/main'} />;
-      }
-      alert(error.response?.data.errorMessage);
+  if (!data && !isSuccess) {
+    if (pathname === '/login' || pathname === '/') {
+      return <Outlet />;
     } else {
-      if (data && isSuccess) {
-        return children;
-      }
+      alert('로그인이 필요한 페이지 입니다');
+      return <Navigate to='/' />;
     }
   }
 
-  return <Navigate to={'/'} />;
+  return <Outlet />;
 };
 
 export default AuthRoute;

--- a/src/common/AuthRoute/AuthRoute.tsx
+++ b/src/common/AuthRoute/AuthRoute.tsx
@@ -1,0 +1,31 @@
+import { AxiosError } from 'axios';
+import { ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuthCheck } from '@/hooks/useAuth';
+
+const AuthRoute = ({ children }: { children: ReactNode }) => {
+  const { pathname } = useLocation();
+  const { data, isSuccess, isLoading, error } = useAuthCheck();
+
+  if (isLoading) {
+    return;
+  }
+
+  if (error instanceof AxiosError) {
+    if (error.response?.data.errorCode === 'sec-401/01') {
+      if (pathname === '/login' || pathname === '/') {
+        alert('로그인한 유저는 들어갈 수 없는 페이지 입니다');
+        return <Navigate to={'/main'} />;
+      }
+      alert(error.response?.data.errorMessage);
+    } else {
+      if (data && isSuccess) {
+        return children;
+      }
+    }
+  }
+
+  return <Navigate to={'/'} />;
+};
+
+export default AuthRoute;

--- a/src/common/AuthRoute/AuthRoute.tsx
+++ b/src/common/AuthRoute/AuthRoute.tsx
@@ -16,6 +16,11 @@ const AuthRoute = () => {
     }
   }
 
+  if (pathname === '/login' || pathname === '/') {
+    alert('로그인 한 유저는 접근할 수 없는 페이지 입니다');
+    return <Navigate to='/main' />;
+  }
+
   return <Outlet />;
 };
 

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,4 +1,7 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { AxiosError, AxiosPromise } from 'axios';
+import { getMyProfileInfo } from '@/apis/api';
+import { ApiResponseAccountGetResponse, ErrorResponse } from '@/generated';
 import { guestLoginFn } from '@/pages/StartPage/guestLoginFn';
 import storageFactory from '@/utils/storageFactory';
 
@@ -17,6 +20,36 @@ export const useGuestLogin = ({ onSuccess }: AuthProps = {}) => {
       }
 
       onSuccess?.();
+    },
+  });
+};
+
+/*
+페이지 이동할때마다 새로 쿼리를 업데이트함. => 이동할때마다 인증처리 + 본인정보 저장
+캐시타임을 짧게 가져간다
+*/
+export const useAuthCheck = () => {
+  return useQuery<
+    AxiosPromise<ApiResponseAccountGetResponse>,
+    Error | AxiosError<ErrorResponse>
+  >({
+    queryFn: getMyProfileInfo,
+    queryKey: ['getMyProfileInfo'],
+    retryOnMount: false,
+    gcTime: 0,
+    throwOnError: (e) => {
+      if (!(e instanceof AxiosError)) {
+        return true;
+      }
+      if (
+        e.response?.status === 400 ||
+        e.response?.status === 401 ||
+        e.response?.status === 404 ||
+        e.response?.status === 409
+      ) {
+        return false;
+      }
+      return true;
     },
   });
 };

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -9,7 +9,7 @@ export interface AuthProps {
   onSuccess?: () => void;
 }
 
-const { setItem } = storageFactory(localStorage);
+const { setItem, getItem } = storageFactory(localStorage);
 
 export const useGuestLogin = ({ onSuccess }: AuthProps = {}) => {
   return useMutation({
@@ -37,6 +37,8 @@ export const useAuthCheck = () => {
     queryKey: ['getMyProfileInfo'],
     retryOnMount: false,
     gcTime: 0,
+    refetchOnWindowFocus: false,
+    enabled: !!getItem('MyToken', ''),
     throwOnError: (e) => {
       if (!(e instanceof AxiosError)) {
         return true;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,10 @@
 import './index.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { createBrowserRouter, Outlet, RouterProvider } from 'react-router-dom';
+import { ErrorBoundary } from 'react-error-boundary';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from './App.tsx';
+import AuthRoute from './common/AuthRoute/AuthRoute.tsx';
 import Header from './common/Header/Header.tsx';
 import BodyLayout from './common/Layout/BodyLayout.tsx';
 import Layout from './common/Layout/Layout.tsx';
@@ -21,14 +23,14 @@ export const router = createBrowserRouter([
       {
         path: '/',
         element: (
-          <>
-            <Layout>
-              <Header />
-              <BodyLayout>
-                <Outlet />
-              </BodyLayout>
-            </Layout>
-          </>
+          <Layout>
+            <Header />
+            <BodyLayout>
+              <ErrorBoundary fallback={<div>연유를 모르는 에러</div>}>
+                <AuthRoute />
+              </ErrorBoundary>
+            </BodyLayout>
+          </Layout>
         ),
         children: [
           {


### PR DESCRIPTION
## 📋 Issue Number
close #68 

## 💻 구현 내용

- 라우팅마다 인증로직을 호출하는 컴포넌트를 만들었습니다 (AuthRoute)
- 인증된유저인지 확인하는 함수는 getMyProfile을 한번 래핑한 useAuth입니다
- **로그인한 유저만 갈 수 있는 페이지,** **로그인 한 유저는 갈 수 없는 페이지** 두개로 나뉘었습니다

## 📷 Screenshots
![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/d4780b3a-98ed-4bb5-8d31-250b3440d720)
![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/4a3464d9-cab4-47b5-9314-6149b23850b3)


## 🤔 고민사항
AuthRoute에서 pathname을 호출하는게 맞나 싶습니다...!
그리고 찾아보니 private route같은 기능은 react-router-dom 6.4v에서 beforeloader같은 기능으로 정식출시 된다네요ㅎㅎ
