### PR TITLE
[Refactor] websocket 훅, 에러바운더리

### DIFF
--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -61,9 +61,12 @@ const GamePage = () => {
   return (
     <>
       <IngameWSErrorBoundary>
-        {(ingameRoomRes) => (
+        {(ingameRoomRes, publishIngame) => (
           <>
-            <GameWord ingameRoomRes={ingameRoomRes} />
+            <GameWord
+              ingameRoomRes={ingameRoomRes}
+              publishIngame={publishIngame}
+            />
             {/* // TODO : issue#92 roomInfo전체를 store에 가지면 그걸로 selectedMode 판단 */}
 
             {/* {selectedMode === 'SENTENCE' && (

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -43,12 +43,10 @@ const GamePage = () => {
   if (!roomId || isWsError) {
     return <WsError />;
   }
-  if (isPlaying) {
+  if (isPlaying || isKicked) {
     navigate('/main', { replace: true });
   }
-  if (isKicked) {
-    navigate('/main', { replace: true });
-  }
+
   if (!didAdminStart) {
     return (
       <GameWaitingRoom

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -2,11 +2,12 @@ import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useRoomIdStore from '@/store/useRoomIdStore';
 import WsError from './common/WsError';
-import GameCode from './GameCode/GameCode';
-import GameSentence from './GameSentence/GameSentence';
+// import GameCode from './GameCode/GameCode';
+// import GameSentence from './GameSentence/GameSentence';
 import GameWaitingRoom from './GameWaitingRoom/GameWaitingRoom';
 import GameWord from './GameWord/GameWord';
 import useWebsocket from './hooks/useWebsocket';
+import { IngameWSErrorBoundary } from './IngameWSErrorBoundary';
 
 const GamePage = () => {
   // TODO: 초대로 들어온 사람이라면 url의 해시값->정제->유효검사 후 상태값) 으로 방번호 추출
@@ -21,6 +22,8 @@ const GamePage = () => {
   } = useWebsocket(roomId);
   const navigate = useNavigate();
 
+  // 아래 TODO
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [selectedMode, isPlaying] = useMemo(
     () => [gameRoomRes.roomInfo?.gameMode, gameRoomRes.roomInfo?.isPlaying],
     [gameRoomRes.roomInfo]
@@ -56,11 +59,27 @@ const GamePage = () => {
       />
     );
   }
+
   return (
     <>
-      {selectedMode === 'SENTENCE' && <GameSentence />}
-      {selectedMode === 'CODE' && <GameCode />}
-      {selectedMode === 'WORD' && <GameWord />}
+      <IngameWSErrorBoundary>
+        {(ingameRoomRes) => (
+          <>
+            <GameWord ingameRoomRes={ingameRoomRes} />
+            {/* // TODO : issue#92 roomInfo전체를 store에 가지면 그걸로 selectedMode 판단 */}
+
+            {/* {selectedMode === 'SENTENCE' && (
+              <GameSentence ingameRoomRes={ingameRoomRes} />
+            )}
+            {selectedMode === 'CODE' && (
+              <GameCode ingameRoomRes={ingameRoomRes} />
+            )}
+            {selectedMode === 'WORD' && (
+              <GameWord ingameRoomRes={ingameRoomRes} />
+            )} */}
+          </>
+        )}
+      </IngameWSErrorBoundary>
     </>
   );
 };

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
@@ -1,7 +1,7 @@
 import * as Avatar from '@radix-ui/react-avatar';
 import { useMemo } from 'react';
 import close from '@/assets/close.png';
-import { handlePubKickUserType, I_AllMember } from '../types/websocketType';
+import { HandlePubKickUserType, I_AllMember } from '../types/websocketType';
 
 const GameRoomUserItem = ({
   hostId,
@@ -12,14 +12,15 @@ const GameRoomUserItem = ({
   hostId: number | undefined;
   gameRoomUser: I_AllMember;
   userId: number;
-  handlePubKickUser: handlePubKickUserType;
+  handlePubKickUser: HandlePubKickUserType;
 }) => {
   const rank = 3; // TODO : 회원조회 쿼리 값으로 변경
 
   const { memberId, nickname, readyStatus: isReady } = gameRoomUser;
 
+  const isAdmin = useMemo(() => hostId === memberId, [hostId, memberId]); // 방장인지
   const isAdminMe = useMemo(() => hostId === userId, [hostId, userId]); //본인이 방장인지
-  const isMe = useMemo(() => memberId === userId, [memberId, userId]); // 각 유저가 본인인지
+  const isMe = useMemo(() => memberId === userId, [memberId, userId]); // 각 유저가 본인인지 -> 방장이자 본인일떄 강퇴식별용
 
   return (
     <div className='w-[25.8rem] h-[21.2rem] p-[1.6rem] pb-[4rem] relative flex flex-col bg-white shadow-md shadow-black/50 rounded-[2.5rem]'>
@@ -60,7 +61,7 @@ const GameRoomUserItem = ({
       </div>
       {((isAdminMe && isMe) || isReady) && (
         <div className='absolute w-[13rem] h-[4rem] rounded-[2rem_0_2.5rem] right-0 bottom-0 text-center leading-[4rem] font-[Giants-Inline] bg-green-100'>
-          {isAdminMe && isMe ? '방장' : isReady && '준비'}
+          {isAdmin ? '방장' : isReady && '준비'}
         </div>
       )}
     </div>

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomUserList.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomUserList.tsx
@@ -1,4 +1,4 @@
-import { handlePubKickUserType, I_AllMember } from '../types/websocketType';
+import { HandlePubKickUserType, I_AllMember } from '../types/websocketType';
 import GameRoomUserItem from './GameRoomUserItem';
 
 const GameRoomUserList = ({
@@ -10,7 +10,7 @@ const GameRoomUserList = ({
   gameRoomUserList: I_AllMember[];
   hostId: number | undefined;
   userId: number;
-  handlePubKickUser: handlePubKickUserType;
+  handlePubKickUser: HandlePubKickUserType;
 }) => {
   return (
     <>

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -3,6 +3,7 @@ import Divider from '@/common/Divider/Divider';
 import Dashboard from '@/common/Ingame/Dashboard';
 import IngameHeader from '@/common/Ingame/IngameHeader';
 import Input from '@/common/Input/Input';
+import { I_IngameWsResponse } from '../types/websocketType';
 import { wordDummy, wordRankDummy } from './wordDummy';
 
 const EMPTY_WORD = 20;
@@ -68,7 +69,8 @@ const WordRank = (data: WordRankProps) => {
   );
 };
 
-const GameWord = () => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const GameWord = ({ ingameRoomRes }: { ingameRoomRes: I_IngameWsResponse }) => {
   return (
     <>
       <IngameHeader />

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -69,8 +69,15 @@ const WordRank = (data: WordRankProps) => {
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const GameWord = ({ ingameRoomRes }: { ingameRoomRes: I_IngameWsResponse }) => {
+const GameWord = ({
+  ingameRoomRes,
+  publishIngame,
+}: {
+  ingameRoomRes?: I_IngameWsResponse;
+  publishIngame: (destination: string, payload: object) => void;
+}) => {
+  // eslint-disable-next-line no-console
+  console.log(ingameRoomRes, publishIngame); //unused disable용 콘솔입니다.
   return (
     <>
       <IngameHeader />

--- a/src/pages/GamePage/IngameWSErrorBoundary.tsx
+++ b/src/pages/GamePage/IngameWSErrorBoundary.tsx
@@ -1,0 +1,16 @@
+import useRoomIdStore from '@/store/useRoomIdStore';
+import WsError from './common/WsError';
+import useIngameWebsocket from './hooks/useIngameWebsocket';
+import { I_IngameWsResponse } from './types/websocketType';
+
+export const IngameWSErrorBoundary = ({
+  children,
+}: {
+  children: (ingameRoomRes: I_IngameWsResponse) => JSX.Element;
+}) => {
+  const { roomId } = useRoomIdStore();
+
+  const { ingameRoomRes, isWsError } = useIngameWebsocket(roomId);
+
+  return isWsError ? <WsError /> : children(ingameRoomRes);
+};

--- a/src/pages/GamePage/IngameWSErrorBoundary.tsx
+++ b/src/pages/GamePage/IngameWSErrorBoundary.tsx
@@ -6,11 +6,15 @@ import { I_IngameWsResponse } from './types/websocketType';
 export const IngameWSErrorBoundary = ({
   children,
 }: {
-  children: (ingameRoomRes: I_IngameWsResponse) => JSX.Element;
+  children: (
+    ingameRoomRes: I_IngameWsResponse,
+    publishIngame: (destination: string, payload: object) => void
+  ) => JSX.Element;
 }) => {
   const { roomId } = useRoomIdStore();
 
-  const { ingameRoomRes, isWsError } = useIngameWebsocket(roomId);
+  const { ingameRoomRes, isWsError, publishIngame } =
+    useIngameWebsocket(roomId);
 
-  return isWsError ? <WsError /> : children(ingameRoomRes);
+  return isWsError ? <WsError /> : children(ingameRoomRes, publishIngame);
 };

--- a/src/pages/GamePage/hooks/useIngameWebsocket.ts
+++ b/src/pages/GamePage/hooks/useIngameWebsocket.ts
@@ -5,6 +5,11 @@ import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
 import { getToken } from '@/utils/getToken';
 import { I_IngameWsResponse } from '../types/websocketType';
 
+type PayloadType =
+  | { info: number }
+  | { 'word-info': string }
+  | { currentRound: number };
+
 const useIngameWebsocket = (roomId: number | null) => {
   const stompClient = useRef<Client>();
   const [ingameRoomRes, setIngameRoomRes] = useState({} as I_IngameWsResponse);
@@ -66,7 +71,7 @@ const useIngameWebsocket = (roomId: number | null) => {
     };
   }, []);
 
-  const publishIngame = (destination: string, payload: object) => {
+  const publishIngame = (destination: string, payload: PayloadType) => {
     stompClient.current?.publish({
       destination: `/to/game/${roomId}${destination}`,
       headers: connectHeaders,

--- a/src/pages/GamePage/hooks/useIngameWebsocket.ts
+++ b/src/pages/GamePage/hooks/useIngameWebsocket.ts
@@ -51,6 +51,8 @@ const useIngameWebsocket = (roomId: number | null) => {
 
     const onMessageReceived = ({ body }: { body: string }) => {
       const responsePublish = JSON.parse(body);
+      // eslint-disable-next-line no-console
+      console.log('responsePublish-----', responsePublish);
       setIngameRoomRes(responsePublish);
       if (checkIsEmptyObj(responsePublish)) {
         setIsWsError(true);
@@ -66,32 +68,14 @@ const useIngameWebsocket = (roomId: number | null) => {
 
   const publishIngame = (destination: string, payload: object) => {
     stompClient.current?.publish({
-      destination: `/to/game${destination}`,
+      destination: `/to/game/${roomId}${destination}`,
       headers: connectHeaders,
       body: JSON.stringify(payload),
     });
   };
 
-  ///to/game/{roomId}/info  ( 문장, 코드 )
-  const handlePubInfo = (roomId: number, currentScore: number) => {
-    publishIngame(`/${roomId}/info`, { currentScore: currentScore });
-  };
-
-  ///to/game/{roomId}/word-info  ( 단어 )
-  const handlePubWordInfo = (roomId: number, word: string) => {
-    publishIngame(`/${roomId}/word-info`, { word: word });
-  };
-
-  ///to/game/{roomId}/round-finish ( 본인 라운드 종료 발행 )
-  const handlePubRoundFinish = (roomId: number, currentRound: number) => {
-    publishIngame(`/${roomId}/round-finish`, { currentRound: currentRound });
-  };
-
   return {
     ingameRoomRes,
-    handlePubInfo,
-    handlePubWordInfo,
-    handlePubRoundFinish,
     publishIngame,
     isWsError,
   };

--- a/src/pages/GamePage/hooks/useIngameWebsocket.ts
+++ b/src/pages/GamePage/hooks/useIngameWebsocket.ts
@@ -2,15 +2,15 @@ import { Client } from '@stomp/stompjs';
 import { useEffect, useRef, useState } from 'react';
 import { BASE_PATH } from '@/generated/base';
 import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
+import { getToken } from '@/utils/getToken';
 import { I_IngameWsResponse } from '../types/websocketType';
-import { useToken } from './useToken';
 
 const useIngameWebsocket = (roomId: number | null) => {
   const stompClient = useRef<Client>();
   const [ingameRoomRes, setIngameRoomRes] = useState({} as I_IngameWsResponse);
   const [isWsError, setIsWsError] = useState(false);
 
-  const { connectHeaders } = useToken();
+  const connectHeaders = getToken();
 
   useEffect(() => {
     if (!roomId) {

--- a/src/pages/GamePage/hooks/useIngameWebsocket.ts
+++ b/src/pages/GamePage/hooks/useIngameWebsocket.ts
@@ -24,6 +24,7 @@ const useIngameWebsocket = (roomId: number | null) => {
       onConnect: () => {
         if (roomId) {
           onConnected();
+          handleConnectGame(roomId);
         }
       },
       onDisconnect: () => {},
@@ -40,6 +41,12 @@ const useIngameWebsocket = (roomId: number | null) => {
         (e) => onMessageReceived(e),
         connectHeaders
       );
+    };
+    const handleConnectGame = (roomId: number) => {
+      client.publish({
+        destination: `/to/game/${roomId}/connect`,
+        headers: connectHeaders,
+      });
     };
 
     const onMessageReceived = ({ body }: { body: string }) => {
@@ -85,6 +92,7 @@ const useIngameWebsocket = (roomId: number | null) => {
     handlePubInfo,
     handlePubWordInfo,
     handlePubRoundFinish,
+    publishIngame,
     isWsError,
   };
 };

--- a/src/pages/GamePage/hooks/useIngameWebsocket.ts
+++ b/src/pages/GamePage/hooks/useIngameWebsocket.ts
@@ -2,19 +2,15 @@ import { Client } from '@stomp/stompjs';
 import { useEffect, useRef, useState } from 'react';
 import { BASE_PATH } from '@/generated/base';
 import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
-import storageFactory from '@/utils/storageFactory';
 import { I_IngameWsResponse } from '../types/websocketType';
+import { useToken } from './useToken';
 
 const useIngameWebsocket = (roomId: number | null) => {
   const stompClient = useRef<Client>();
   const [ingameRoomRes, setIngameRoomRes] = useState({} as I_IngameWsResponse);
   const [isWsError, setIsWsError] = useState(false);
-  const { getItem } = storageFactory(localStorage);
 
-  const token = getItem('MyToken', '');
-  const connectHeaders = {
-    Authorization: `Bearer ${token}`,
-  };
+  const { connectHeaders } = useToken();
 
   useEffect(() => {
     if (!roomId) {

--- a/src/pages/GamePage/hooks/useToken.ts
+++ b/src/pages/GamePage/hooks/useToken.ts
@@ -1,0 +1,11 @@
+import storageFactory from '@/utils/storageFactory';
+
+export const useToken = () => {
+  const { getItem } = storageFactory(localStorage);
+  const token = getItem('MyToken', '');
+  const connectHeaders = {
+    Authorization: `Bearer ${token}`,
+  };
+
+  return { connectHeaders };
+};

--- a/src/pages/GamePage/hooks/useWebsocket.ts
+++ b/src/pages/GamePage/hooks/useWebsocket.ts
@@ -2,23 +2,20 @@ import { Client } from '@stomp/stompjs';
 import { useEffect, useRef, useState } from 'react';
 import { BASE_PATH } from '@/generated/base';
 import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
-import storageFactory from '@/utils/storageFactory';
 import { I_GameRoomResponse } from '../types/websocketType';
+import { useToken } from './useToken';
 
 const useWebsocket = (roomId: number | null) => {
   const stompClient = useRef<Client>();
   const [gameRoomRes, setGameRoomRes] = useState({} as I_GameRoomResponse);
   const [isWsError, setIsWsError] = useState(false);
-  const { getItem } = storageFactory(localStorage);
 
-  const token = getItem('MyToken', '');
-  const connectHeaders = {
-    Authorization: `Bearer ${token}`,
-  };
+  const { connectHeaders } = useToken();
 
   useEffect(() => {
     if (!roomId) {
       setIsWsError(true);
+      return;
     }
     const client = new Client({
       webSocketFactory: () => new SockJS(`${BASE_PATH}/ws`),

--- a/src/pages/GamePage/hooks/useWebsocket.ts
+++ b/src/pages/GamePage/hooks/useWebsocket.ts
@@ -2,15 +2,15 @@ import { Client } from '@stomp/stompjs';
 import { useEffect, useRef, useState } from 'react';
 import { BASE_PATH } from '@/generated/base';
 import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
+import { getToken } from '@/utils/getToken';
 import { I_GameRoomResponse } from '../types/websocketType';
-import { useToken } from './useToken';
 
 const useWebsocket = (roomId: number | null) => {
   const stompClient = useRef<Client>();
   const [gameRoomRes, setGameRoomRes] = useState({} as I_GameRoomResponse);
   const [isWsError, setIsWsError] = useState(false);
 
-  const { connectHeaders } = useToken();
+  const connectHeaders = getToken();
 
   useEffect(() => {
     if (!roomId) {

--- a/src/utils/getToken.ts
+++ b/src/utils/getToken.ts
@@ -1,11 +1,11 @@
 import storageFactory from '@/utils/storageFactory';
 
-export const useToken = () => {
+export const getToken = () => {
   const { getItem } = storageFactory(localStorage);
   const token = getItem('MyToken', '');
   const connectHeaders = {
     Authorization: `Bearer ${token}`,
   };
 
-  return { connectHeaders };
+  return connectHeaders;
 };


### PR DESCRIPTION
## 📋 Issue Number
close #

## 💻 구현 내용

- 웹소켓 훅에서 token을 받아 헤더만드는 로직을 훅으로 분리했습니다.
  -> 🤔 훅일필요는 없을까요? connectHeaders라는 객체를 반환하는 함수로 해도 될까요?

- 게임이 시작되어 교체되는 인게임 컴포넌트 리턴 부분을 에러바운더리로 감쌌습니다. 
  -> 🤔 알맞은 방법일까요!
  -> 🤔 연결이 잘못되거나 네트워크 등 예상 못한 에러 처리를 할 수있는거라고 생각했는데, 맞을까요 ?

- **useIngameWebsocket으로 부터 publishIngame 함수만 리턴**받습니다. 여기에 게임 별 엔드포인트를 destionation인자로 보내면됩니다! roomId까지 함수 안에서 가지기 때문에 /info, /round-finish 만 보내면 됩니다!! 

## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
