### PR TITLE
[Feat] 인게임 헤더

### DIFF
--- a/src/common/Ingame/IngameHeader.tsx
+++ b/src/common/Ingame/IngameHeader.tsx
@@ -1,19 +1,39 @@
-import { gameInfoDummy } from '@/pages/GamePage/GameDummys';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import DisconnectModal from '@/pages/GamePage/common/DisconnectModal';
+import useRoomInfoStore from '@/store/useRoomInfoStore';
 import Backward from '../Backward/Backward';
 
 const IngameHeader = () => {
-  const { gameRoomName, gameRoomUserList, gameRoundTotal } = gameInfoDummy; // TODO : 캐싱쿼리값
-  const gameRoundCurrent = 2; //TODO: 현재 라운드로 수정. zustand?
+  const { roomInfo } = useRoomInfoStore();
+  const [isAlert, setIsAlert] = useState(false);
+  const navigate = useNavigate();
+
+  const handleClickBackward = () => {
+    setIsAlert(true);
+  };
 
   return (
-    <div className='flex flex-row items-center gap-20 pb-12 font-[Giants-Inline]'>
-      <Backward />
-      <div className='w-[40rem] truncate text-[4rem]'>{gameRoomName}</div>
-      <div className='grow'>참여 {gameRoomUserList.length}명</div>
-      <div className='text-[3rem]'>
-        🏁 {gameRoundCurrent} / {gameRoundTotal}
+    <>
+      <DisconnectModal
+        isOpen={isAlert}
+        handleClickAction={() => {
+          navigate('/main', { replace: true });
+          navigate(0);
+        }}
+        handleClickCancel={() => {
+          setIsAlert(false);
+        }}
+      />
+      <div className='flex flex-row items-center gap-20 pb-12 font-[Giants-Inline] select-none'>
+        <Backward handleClickBackward={handleClickBackward} />
+        <div className='w-[40rem] truncate text-[4rem]'>{roomInfo?.title}</div>
+        <div className='grow'>참여 {roomInfo?.currentPlayer}명</div>
+        <div className='text-[3rem]'>
+          🏁 {roomInfo?.currentPlayer} / {roomInfo?.maxPlayer}
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 export default IngameHeader;

--- a/src/pages/GamePage/IngameWSErrorBoundary.tsx
+++ b/src/pages/GamePage/IngameWSErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import useRoomIdStore from '@/store/useRoomIdStore';
+import useRoomInfoStore from '@/store/useRoomInfoStore';
 import WsError from './common/WsError';
 import useIngameWebsocket from './hooks/useIngameWebsocket';
 import { I_IngameWsResponse } from './types/websocketType';
@@ -11,7 +11,7 @@ export const IngameWSErrorBoundary = ({
     publishIngame: (destination: string, payload: object) => void
   ) => JSX.Element;
 }) => {
-  const { roomId } = useRoomIdStore();
+  const { roomId } = useRoomInfoStore();
 
   const { ingameRoomRes, isWsError, publishIngame } =
     useIngameWebsocket(roomId);

--- a/src/pages/GamePage/common/DisconnectModal.tsx
+++ b/src/pages/GamePage/common/DisconnectModal.tsx
@@ -15,7 +15,7 @@ const DisconnectModal = ({
       <AlertDialog.Trigger asChild></AlertDialog.Trigger>
       <AlertDialog.Portal>
         <AlertDialog.Overlay className='fixed inset-0 w-[100vw] h-[100vh] bg-black/30 animate-[overlayShow_150ms_cubic-bezier(0.16,1,0.3,1)]' />
-        <AlertDialog.Content className='data-[state=open]:animate-contentShow fixed top-[50%] left-[50%] max-h-[85vh] w-[90vw] max-w-[500px] translate-x-[-50%] translate-y-[-50%] rounded-[6px] bg-white p-[25px] shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none'>
+        <AlertDialog.Content className='data-[state=open]:animate-contentShow fixed top-[50%] left-[50%] max-h-[85vh] w-[90vw] max-w-[500px] translate-x-[-50%] translate-y-[-50%] rounded-[6px] bg-white p-[25px] shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none z-10'>
           <AlertDialog.Title className='text-mauve12 m-0 text-[17px] font-medium'>
             정말로 게임방을 나가시겠어요?
           </AlertDialog.Title>


### PR DESCRIPTION
## 📋 Issue Number
close #102 

## 💻 구현 내용

- 인게임 헤더에 더미데이터 대신 useRoomInfoStore에 저장한 roomInfo 값을 넘깁니다

## 📷 Screenshots
<img width="1147" alt="스크린샷 2024-03-04 오전 10 46 12" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/781c8903-dcd0-473a-b6c8-186aa49117ad">


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
