### PR TITLE
[Feat] 카카오 소셜 로그인

### DIFF
--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -18,6 +18,7 @@ export const {
   enterGameRoom,
   getMyProfileInfo,
   guestLogin,
+  kakaoLogin,
   login,
   logout,
   reIssueAccessToken,

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -6,10 +6,10 @@ import storageFactory from '@/utils/storageFactory';
 const { getItem } = storageFactory(localStorage);
 
 //임시로 MyToken이라는 값을 정해두었습니다
-const axiosInstance = axios.create();
-axiosInstance.interceptors.request.use((config) => {
-  config.headers.Authorization = `Bearer ${getItem('MyToken', '')}`;
-  return config;
+export const axiosInstance = axios.create({
+  headers: {
+    Authorization: `Bearer ${getItem('MyToken', '')}`,
+  },
 });
 
 export const {

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -6,10 +6,10 @@ import storageFactory from '@/utils/storageFactory';
 const { getItem } = storageFactory(localStorage);
 
 //임시로 MyToken이라는 값을 정해두었습니다
-export const axiosInstance = axios.create({
-  headers: {
-    Authorization: `Bearer ${getItem('MyToken', '')}`,
-  },
+const axiosInstance = axios.create();
+axiosInstance.interceptors.request.use((config) => {
+  config.headers.Authorization = `Bearer ${getItem('MyToken', '')}`;
+  return config;
 });
 
 export const {

--- a/src/common/AuthRoute/AuthRoute.tsx
+++ b/src/common/AuthRoute/AuthRoute.tsx
@@ -10,7 +10,11 @@ const AuthRoute = () => {
 
   //로컬스토리지에 토큰이 없을때
   if (!getItem('MyToken', '')) {
-    if (pathname === '/login' || pathname === '/') {
+    if (
+      pathname === '/login' ||
+      pathname === '/' ||
+      pathname === '/login/oauth2/code/kakao'
+    ) {
       return <Outlet />;
     }
     alert('로그인이 필요한 페이지 입니다');
@@ -25,7 +29,11 @@ const AuthRoute = () => {
   //로그인 하지 않았을 때(400, 401, 404, 409일때 로그인 안했다고 처리함)
   if (error) {
     //로그인관련 페이지라면 그대로 보여준다
-    if (pathname === '/login' || pathname === '/') {
+    if (
+      pathname === '/login' ||
+      pathname === '/' ||
+      pathname === '/login/oauth2/code/kakao'
+    ) {
       return <Outlet />;
     }
 
@@ -35,7 +43,11 @@ const AuthRoute = () => {
   }
 
   //로그인 했을때, 로그인 관련 페이지는 접근 불가
-  if (pathname === '/login' || pathname === '/') {
+  if (
+    pathname === '/login' ||
+    pathname === '/' ||
+    pathname === '/login/oauth2/code/kakao'
+  ) {
     alert('로그인 한 유저는 접근할 수 없는 페이지 입니다');
     return <Navigate to='/main' />;
   }

--- a/src/common/AuthRoute/AuthRoute.tsx
+++ b/src/common/AuthRoute/AuthRoute.tsx
@@ -2,6 +2,12 @@ import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useAuthCheck } from '@/hooks/useAuth';
 import storageFactory from '@/utils/storageFactory';
 
+const authMap = new Map([
+  ['/', 1],
+  ['/login', 1],
+  ['/login/oauth2/code/kakao', 1],
+]);
+
 const AuthRoute = () => {
   const { pathname } = useLocation();
   const { error, isPending } = useAuthCheck();
@@ -10,11 +16,7 @@ const AuthRoute = () => {
 
   //로컬스토리지에 토큰이 없을때
   if (!getItem('MyToken', '')) {
-    if (
-      pathname === '/login' ||
-      pathname === '/' ||
-      pathname === '/login/oauth2/code/kakao'
-    ) {
+    if (authMap.get(pathname)) {
       return <Outlet />;
     }
     alert('로그인이 필요한 페이지 입니다');
@@ -29,11 +31,7 @@ const AuthRoute = () => {
   //로그인 하지 않았을 때(400, 401, 404, 409일때 로그인 안했다고 처리함)
   if (error) {
     //로그인관련 페이지라면 그대로 보여준다
-    if (
-      pathname === '/login' ||
-      pathname === '/' ||
-      pathname === '/login/oauth2/code/kakao'
-    ) {
+    if (authMap.get(pathname)) {
       return <Outlet />;
     }
 
@@ -43,11 +41,7 @@ const AuthRoute = () => {
   }
 
   //로그인 했을때, 로그인 관련 페이지는 접근 불가
-  if (
-    pathname === '/login' ||
-    pathname === '/' ||
-    pathname === '/login/oauth2/code/kakao'
-  ) {
+  if (authMap.get(pathname)) {
     alert('로그인 한 유저는 접근할 수 없는 페이지 입니다');
     return <Navigate to='/main' />;
   }

--- a/src/common/Header/Header.tsx
+++ b/src/common/Header/Header.tsx
@@ -11,6 +11,7 @@ import logo_car from '@/assets/logo_car.png';
 import logo_taza from '@/assets/logo_taza.png';
 import { PAUSE, PLAY } from '@/common/Header/constants/volume';
 import { exchangeVolumeState } from '@/common/Header/utils/exchangeVolumeState';
+import { useAuthCheck } from '@/hooks/useAuth';
 import WrappedIcon from '../WrappedIcon/WrappedIcon';
 
 export type VolumeType = 'play' | 'pause';
@@ -36,6 +37,8 @@ const Header = () => {
     effect: PAUSE,
   });
   const navigate = useNavigate();
+
+  const { data } = useAuthCheck();
 
   return (
     <header className='bg-green-100 h-[4.5rem] w-[100%] shrink-0 flex justify-between px-[4rem]'>
@@ -71,14 +74,25 @@ const Header = () => {
           className='hover:bg-gray-100 size-[2rem] flex items-center justify-center'>
           <WrappedIcon IconComponent={mappedIcons.effect[volume.effect]} />
         </button>
-        <Avatar.Root className='cursor-pointer'>
-          <Avatar.Image
-            className='size-[3.5rem] rounded-full'
-            src='https://picsum.photos/id/237/200/300'
-            alt='프로필 이미지'
-          />
-          <Avatar.Fallback delayMs={1000}>프로필</Avatar.Fallback>
-        </Avatar.Root>
+        {data ? (
+          <Avatar.Root className='cursor-pointer'>
+            <Avatar.Image
+              className='size-[3.5rem] rounded-full'
+              src='https://picsum.photos/id/237/200/300'
+              alt='프로필 이미지'
+            />
+            <Avatar.Fallback delayMs={1000}>프로필</Avatar.Fallback>
+          </Avatar.Root>
+        ) : (
+          <button
+            onClick={() => {
+              navigate('/login');
+              navigate(0);
+            }}
+            className='hover:bg-gray-100 flex items-center justify-center'>
+            로그인
+          </button>
+        )}
       </section>
     </header>
   );

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
-import { getMyProfileInfo, guestLogin } from '@/apis/api';
+import { getMyProfileInfo, guestLogin, kakaoLogin } from '@/apis/api';
 import {
   ApiResponseAccountGetResponse,
   ApiResponseAuthResponse,
@@ -21,6 +21,40 @@ export const useGuestLogin = ({ onSuccess }: AuthProps = {}) => {
   >({
     mutationFn: guestLogin,
     mutationKey: ['guestLogin'],
+    onSuccess: (e) => {
+      const token = e.data.data?.accessToken;
+
+      if (token) {
+        setItem('MyToken', token);
+      }
+
+      onSuccess?.(e);
+    },
+    throwOnError: (e) => {
+      if (!(e instanceof AxiosError)) {
+        return true;
+      }
+      if (
+        e.response?.status === 400 ||
+        e.response?.status === 401 ||
+        e.response?.status === 403 ||
+        e.response?.status === 500
+      ) {
+        return false;
+      }
+      return true;
+    },
+  });
+};
+
+export const useKaKaoLogin = ({ onSuccess }: AuthProps = {}) => {
+  return useMutation<
+    AxiosResponse<ApiResponseAuthResponse>,
+    Error | AxiosError,
+    string
+  >({
+    mutationFn: kakaoLogin,
+    mutationKey: ['kakaoLogin'],
     onSuccess: (e) => {
       const token = e.data.data?.accessToken;
 

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -10,6 +10,7 @@ import storageFactory from '@/utils/storageFactory';
 
 export interface AuthProps {
   onSuccess?: (e: AxiosResponse<ApiResponseAuthResponse>) => void;
+  onError?: (e: AxiosError) => void;
 }
 
 const { setItem, getItem } = storageFactory(localStorage);
@@ -63,6 +64,9 @@ export const useKaKaoLogin = ({ onSuccess }: AuthProps = {}) => {
       }
 
       onSuccess?.(e);
+    },
+    onError: (e) => {
+      throw new Error(e.message);
     },
     throwOnError: (e) => {
       if (!(e instanceof AxiosError)) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import Header from './common/Header/Header.tsx';
 import BodyLayout from './common/Layout/BodyLayout.tsx';
 import Layout from './common/Layout/Layout.tsx';
 import GamePage from './pages/GamePage/GamePage.tsx';
+import KaKaoLoginPage from './pages/KaKaoLoginPage/KaKaoLoginPage.tsx';
 import LoginPage from './pages/LoginPage/LoginPage.tsx';
 import MainPage from './pages/MainPage/MainPage.tsx';
 import NotFoundPage from './pages/NotFoundPage/NotFoundPage.tsx';
@@ -66,6 +67,10 @@ export const router = createBrowserRouter([
           {
             path: '/rank',
             element: <RankPage />,
+          },
+          {
+            path: '/login/oauth2/code/kakao',
+            element: <KaKaoLoginPage />,
           },
           {
             path: '/*',

--- a/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
+++ b/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
@@ -1,0 +1,9 @@
+const KaKaoLoginPage = () => {
+  return (
+    <div>
+      <p>로그인 중입니다.</p>
+      <p>잠시만 기다려주세요.</p>
+    </div>
+  );
+};
+export default KaKaoLoginPage;

--- a/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
+++ b/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
@@ -9,7 +9,7 @@ const KaKaoLoginPage = () => {
     document.location.toString()
   ).searchParams.get('code') as string;
 
-  const { mutateAsync: mutateKaKaoLogin } = useKaKaoLogin({
+  const { mutate: mutateKaKaoLogin } = useKaKaoLogin({
     onSuccess: () => {
       alert('로그인 성공');
       navigate('/main');
@@ -17,19 +17,17 @@ const KaKaoLoginPage = () => {
   });
 
   useEffect(() => {
-    (async () => {
-      if (!AUTHORIZATION_CODE) {
-        navigate('/login');
-        return;
-      }
+    if (!AUTHORIZATION_CODE) {
+      navigate('/login');
+      return;
+    }
 
-      try {
-        mutateKaKaoLogin(AUTHORIZATION_CODE);
-      } catch (error) {
-        //ToDo: Toast 에러 메시지 처리
-        navigate('/login');
-      }
-    })();
+    try {
+      mutateKaKaoLogin(AUTHORIZATION_CODE);
+    } catch (error) {
+      //ToDo: Toast 에러 메시지 처리
+      navigate('/login');
+    }
   }, [AUTHORIZATION_CODE, mutateKaKaoLogin, navigate]);
 
   return (

--- a/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
+++ b/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
@@ -1,18 +1,8 @@
-import axios from 'axios';
-import { BASE_PATH } from '@/generated/base';
-import storageFactory from '@/utils/storageFactory';
-
 const KaKaoLoginPage = () => {
-  const { setItem } = storageFactory(localStorage);
-  const AUTHORIZATION_CODE: string = new URL(
-    document.location.toString()
-  ).searchParams.get('code') as string;
+  // const AUTHORIZATION_CODE: string = new URL(
+  //   document.location.toString()
+  // ).searchParams.get('code') as string;
 
-  axios
-    .post(`${BASE_PATH}/api/v1/auth/login/kakao?code=${AUTHORIZATION_CODE}`)
-    .then((response) => {
-      setItem('MyToken', response.data.accessToken);
-    });
   return (
     <div>
       <p>로그인 중입니다.</p>

--- a/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
+++ b/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
@@ -1,4 +1,18 @@
+import axios from 'axios';
+import { BASE_PATH } from '@/generated/base';
+import storageFactory from '@/utils/storageFactory';
+
 const KaKaoLoginPage = () => {
+  const { setItem } = storageFactory(localStorage);
+  const AUTHORIZATION_CODE: string = new URL(
+    document.location.toString()
+  ).searchParams.get('code') as string;
+
+  axios
+    .post(`${BASE_PATH}/api/v1/auth/login/kakao?code=${AUTHORIZATION_CODE}`)
+    .then((response) => {
+      setItem('MyToken', response.data.accessToken);
+    });
   return (
     <div>
       <p>로그인 중입니다.</p>

--- a/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
+++ b/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
@@ -1,7 +1,32 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useKaKaoLogin } from '@/hooks/useAuth';
+
 const KaKaoLoginPage = () => {
-  // const AUTHORIZATION_CODE: string = new URL(
-  //   document.location.toString()
-  // ).searchParams.get('code') as string;
+  const navigate = useNavigate();
+
+  const AUTHORIZATION_CODE: string = new URL(
+    document.location.toString()
+  ).searchParams.get('code') as string;
+
+  const { mutateAsync: mutateKaKaoLogin } = useKaKaoLogin();
+
+  useEffect(() => {
+    (async () => {
+      if (!AUTHORIZATION_CODE) {
+        navigate('/login');
+        return;
+      }
+
+      try {
+        mutateKaKaoLogin(AUTHORIZATION_CODE);
+        navigate('/main');
+      } catch (error) {
+        //ToDo: Toast 에러 메시지 처리
+        navigate('/login');
+      }
+    })();
+  }, [AUTHORIZATION_CODE, mutateKaKaoLogin, navigate]);
 
   return (
     <div>

--- a/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
+++ b/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
@@ -5,14 +5,16 @@ import { useKaKaoLogin } from '@/hooks/useAuth';
 const KaKaoLoginPage = () => {
   const navigate = useNavigate();
 
-  const AUTHORIZATION_CODE: string = new URL(
-    document.location.toString()
-  ).searchParams.get('code') as string;
+  const url = new URL(document.location.href);
+  const AUTHORIZATION_CODE = url.searchParams.get('code');
 
-  const { mutate: mutateKaKaoLogin } = useKaKaoLogin({
+  const { mutate: mutateKaKaoLogin, error } = useKaKaoLogin({
     onSuccess: () => {
       alert('로그인 성공');
-      navigate('/main');
+      navigate('/main', { replace: true });
+    },
+    onError: (error) => {
+      alert(error.message);
     },
   });
 
@@ -22,18 +24,14 @@ const KaKaoLoginPage = () => {
       return;
     }
 
-    try {
-      mutateKaKaoLogin(AUTHORIZATION_CODE);
-    } catch (error) {
-      //ToDo: Toast 에러 메시지 처리
-      navigate('/login');
-    }
+    mutateKaKaoLogin(AUTHORIZATION_CODE);
   }, [AUTHORIZATION_CODE, mutateKaKaoLogin, navigate]);
 
   return (
     <div>
       <p>로그인 중입니다.</p>
       <p>잠시만 기다려주세요.</p>
+      {error && <p>{error.message}</p>}
     </div>
   );
 };

--- a/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
+++ b/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
@@ -9,7 +9,12 @@ const KaKaoLoginPage = () => {
     document.location.toString()
   ).searchParams.get('code') as string;
 
-  const { mutateAsync: mutateKaKaoLogin } = useKaKaoLogin();
+  const { mutateAsync: mutateKaKaoLogin } = useKaKaoLogin({
+    onSuccess: () => {
+      alert('로그인 성공');
+      navigate('/main');
+    },
+  });
 
   useEffect(() => {
     (async () => {
@@ -20,7 +25,6 @@ const KaKaoLoginPage = () => {
 
       try {
         mutateKaKaoLogin(AUTHORIZATION_CODE);
-        navigate('/main');
       } catch (error) {
         //ToDo: Toast 에러 메시지 처리
         navigate('/login');

--- a/src/pages/KaKaoLoginPage/kakaoAuthApi.ts
+++ b/src/pages/KaKaoLoginPage/kakaoAuthApi.ts
@@ -1,9 +1,0 @@
-import { axiosInstance } from '@/apis/api';
-import { BASE_PATH } from '@/generated/base';
-
-export const kakaoAuthApi = async (code: string) => {
-  const response = await axiosInstance.post(
-    `${BASE_PATH}/api/v1/auth/login/kakao?code=${code}`
-  );
-  return response;
-};

--- a/src/pages/KaKaoLoginPage/kakaoAuthApi.ts
+++ b/src/pages/KaKaoLoginPage/kakaoAuthApi.ts
@@ -1,0 +1,9 @@
+import { axiosInstance } from '@/apis/api';
+import { BASE_PATH } from '@/generated/base';
+
+export const kakaoAuthApi = async (code: string) => {
+  const response = await axiosInstance.post(
+    `${BASE_PATH}/api/v1/auth/login/kakao?code=${code}`
+  );
+  return response;
+};

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,6 +1,7 @@
 import google from '@/assets/login/g-logo.png';
 import kakao from '@/assets/login/k-logo.png';
 import logo from '@/assets/logo_big.png';
+import { KAKAO_AUTH_URL } from './OAuth';
 
 const LoginPage = () => {
   return (
@@ -10,14 +11,16 @@ const LoginPage = () => {
         className='object-cover h-[55rem]'
       />
       <div className='flex flex-col gap-[0.5rem]'>
-        <div className='flex items-center gap-[8rem] bg-[#FEE500] w-[30rem] h-[4.5rem] rounded-[0.6rem]'>
-          <img
-            src={kakao}
-            alt='Kakao logo'
-            className='w-[2rem] h-[2rem] ml-5'
-          />
-          <span className='text-[1.4rem]'>카카오 로그인</span>
-        </div>
+        <a href={KAKAO_AUTH_URL}>
+          <div className='flex items-center gap-[8rem] bg-[#FEE500] w-[30rem] h-[4.5rem] rounded-[0.6rem]'>
+            <img
+              src={kakao}
+              alt='Kakao logo'
+              className='w-[2rem] h-[2rem] ml-5'
+            />
+            <span className='text-[1.4rem]'>카카오 로그인</span>
+          </div>
+        </a>
         <div className='flex items-center gap-[9rem] bg-[#ffff] w-[30rem] h-[4.5rem] rounded-[0.6rem]'>
           <img
             src={google}

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,9 +1,24 @@
+import axios from 'axios';
 import google from '@/assets/login/g-logo.png';
 import kakao from '@/assets/login/k-logo.png';
 import logo from '@/assets/logo_big.png';
+import { BASE_PATH } from '@/generated/base';
+import storageFactory from '@/utils/storageFactory';
 import { KAKAO_AUTH_URL } from './OAuth';
 
 const LoginPage = () => {
+  const { setItem } = storageFactory(localStorage);
+
+  const AUTHORIZATION_CODE: string = new URL(
+    document.location.toString()
+  ).searchParams.get('code') as string;
+
+  axios
+    .get(`${BASE_PATH}/api/v1/auth/login/kakao?code=${AUTHORIZATION_CODE}`)
+    .then((response) => {
+      setItem('MyToken', response.data.accessToken);
+    });
+
   return (
     <div className='flex flex-col items-center gap-[5rem]'>
       <img

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,24 +1,9 @@
-import axios from 'axios';
 import google from '@/assets/login/g-logo.png';
 import kakao from '@/assets/login/k-logo.png';
 import logo from '@/assets/logo_big.png';
-import { BASE_PATH } from '@/generated/base';
-import storageFactory from '@/utils/storageFactory';
 import { KAKAO_AUTH_URL } from './OAuth';
 
 const LoginPage = () => {
-  const { setItem } = storageFactory(localStorage);
-
-  const AUTHORIZATION_CODE: string = new URL(
-    document.location.toString()
-  ).searchParams.get('code') as string;
-
-  axios
-    .get(`${BASE_PATH}/api/v1/auth/login/kakao?code=${AUTHORIZATION_CODE}`)
-    .then((response) => {
-      setItem('MyToken', response.data.accessToken);
-    });
-
   return (
     <div className='flex flex-col items-center gap-[5rem]'>
       <img

--- a/src/pages/LoginPage/OAuth.ts
+++ b/src/pages/LoginPage/OAuth.ts
@@ -1,0 +1,4 @@
+export const CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
+export const REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
+
+export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code`;


### PR DESCRIPTION
## 📋 Issue Number
close #56 

## 💻 구현 내용

- 카카오 소셜 로그인을 구현했습니다
- 카카오 로그인 버튼 클릭 => 로그인 과정 진행 => 로그인 성공 시 토큰 LocalStorage에 저장 후 `/main`으로 이동하도록 구현
- AuthRoute에 Redirect URI(/login/oauth2/code/kakao) 추가 했습니다

## 📷 Screenshots

## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->

- #105  버그 리포트와 같이 에러가 발생하는데 어떻게 해결하면 좋을까요??
<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
