### PR TITLE
[Feat] 단어 게임 - 발행, 응답 연결

### DIFF
--- a/src/common/Ingame/IngameHeader.tsx
+++ b/src/common/Ingame/IngameHeader.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import DisconnectModal from '@/pages/GamePage/common/DisconnectModal';
 import useRoomInfoStore from '@/store/useRoomInfoStore';
 import Backward from '../Backward/Backward';
@@ -7,7 +6,6 @@ import Backward from '../Backward/Backward';
 const IngameHeader = () => {
   const { roomInfo } = useRoomInfoStore();
   const [isAlert, setIsAlert] = useState(false);
-  const navigate = useNavigate();
 
   const handleClickBackward = () => {
     setIsAlert(true);
@@ -17,10 +15,6 @@ const IngameHeader = () => {
     <>
       <DisconnectModal
         isOpen={isAlert}
-        handleClickAction={() => {
-          navigate('/main', { replace: true });
-          navigate(0);
-        }}
         handleClickCancel={() => {
           setIsAlert(false);
         }}

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -93,10 +93,12 @@ const GamePage = () => {
       <IngameWSErrorBoundary>
         {(ingameRoomRes, publishIngame) => (
           <>
-            <GameWord
-              ingameRoomRes={ingameRoomRes}
-              publishIngame={publishIngame}
-            />
+            {ingameRoomRes.questions && (
+              <GameWord
+                ingameRoomRes={ingameRoomRes}
+                publishIngame={publishIngame}
+              />
+            )}
             {/* // TODO : issue#92 roomInfo전체를 store에 가지면 그걸로 selectedMode 판단 */}
 
             {/* {selectedMode === 'SENTENCE' && (

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import Backward from '@/common/Backward/Backward';
 import DisconnectModal from '../common/DisconnectModal';
 import {
@@ -28,8 +27,6 @@ const GameWaitingRoom = ({
   handlePubKickUser: HandlePubKickUserType;
   userId: number;
 }) => {
-  const navigate = useNavigate();
-
   const { allMembers, roomInfo } = gameRoomRes;
   const [isAlert, setIsAlert] = useState(false);
 
@@ -42,10 +39,6 @@ const GameWaitingRoom = ({
     <>
       <DisconnectModal
         isOpen={isAlert}
-        handleClickAction={() => {
-          navigate('/main', { replace: true });
-          navigate(0);
-        }}
         handleClickCancel={() => {
           setIsAlert(false);
         }}

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -8,6 +8,7 @@ import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
 import { I_IngameWsResponse, PayloadType } from '../types/websocketType';
 import { wordRankDummy } from './wordDummy';
 
+export type WordQuestionType = { [key: string]: number };
 const positions = ['center', 'left', 'right'];
 const WordCell = ({ children }: { children: ReactNode }) => {
   const random = positions[Math.floor(Math.random() * positions.length)];
@@ -73,17 +74,17 @@ const GameWord = ({
   ingameRoomRes?: I_IngameWsResponse;
   publishIngame: (destination: string, payload: PayloadType) => void;
 }) => {
-  // eslint-disable-next-line no-console
-  console.log(ingameRoomRes, publishIngame); //unused disable용 콘솔입니다.
   const { register, handleSubmit, setValue, getValues } = useForm();
-  const { wordsStore, setWords, setWordUsed } = useWordsStore();
+  const { wordsStore, setWordStore, setSubmittedWord } = useWordsStore();
+
   useEffect(() => {
     if (ingameRoomRes?.submittedWord) {
-      const obj = {} as { [key: string]: number | string };
-      obj[ingameRoomRes?.submittedWord] = -1;
-      setWordUsed(obj);
+      const submittedWord: WordQuestionType = {};
+      submittedWord[ingameRoomRes?.submittedWord] = -1;
+      setSubmittedWord(submittedWord);
     }
   }, [ingameRoomRes?.submittedWord]);
+
   if (
     !ingameRoomRes ||
     !ingameRoomRes.questions ||
@@ -93,11 +94,11 @@ const GameWord = ({
   }
 
   if (checkIsEmptyObj(wordsStore)) {
-    const words = {} as { [key: string]: number | string };
+    const words: WordQuestionType = {};
     for (const idx in ingameRoomRes.questions) {
       words[ingameRoomRes.questions[idx].question] = Number(idx);
     }
-    setWords(words);
+    setWordStore(words);
     localStorage.setItem('test', JSON.stringify(ingameRoomRes.questions));
   }
 

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -71,22 +71,21 @@ const GameWord = ({
   ingameRoomRes,
   publishIngame,
 }: {
-  ingameRoomRes?: I_IngameWsResponse;
+  ingameRoomRes: I_IngameWsResponse;
   publishIngame: (destination: string, payload: PayloadType) => void;
 }) => {
   const { register, handleSubmit, setValue, getValues } = useForm();
   const { wordsStore, setWordStore, setSubmittedWord } = useWordsStore();
 
   useEffect(() => {
-    if (ingameRoomRes?.submittedWord) {
+    if (ingameRoomRes.submittedWord) {
       const submittedWord: WordQuestionType = {};
-      submittedWord[ingameRoomRes?.submittedWord] = -1;
+      submittedWord[ingameRoomRes.submittedWord] = -1;
       setSubmittedWord(submittedWord);
     }
-  }, [ingameRoomRes?.submittedWord]);
+  }, [ingameRoomRes.submittedWord]);
 
   if (
-    !ingameRoomRes ||
     !ingameRoomRes.questions ||
     (ingameRoomRes && checkIsEmptyObj(ingameRoomRes))
   ) {
@@ -99,7 +98,6 @@ const GameWord = ({
       words[ingameRoomRes.questions[idx].question] = Number(idx);
     }
     setWordStore(words);
-    localStorage.setItem('test', JSON.stringify(ingameRoomRes.questions));
   }
 
   return (

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -3,8 +3,13 @@ import Divider from '@/common/Divider/Divider';
 import Dashboard from '@/common/Ingame/Dashboard';
 import IngameHeader from '@/common/Ingame/IngameHeader';
 import Input from '@/common/Input/Input';
-import { I_IngameWsResponse, PayloadType } from '../types/websocketType';
-import { wordDummy, wordRankDummy } from './wordDummy';
+import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
+import {
+  I_IngameWsResponse,
+  I_Question,
+  PayloadType,
+} from '../types/websocketType';
+import { wordRankDummy } from './wordDummy';
 
 const EMPTY_WORD = 20;
 const positions = ['center', 'left', 'right'];
@@ -18,10 +23,9 @@ const WordCell = ({ children }: { children: ReactNode }) => {
   );
 };
 // 총 120개의 cell. 서버로부터 받을 단어 100개 + 랜덤20개(EMPTY_WORD)로 구성해야함
-const shuffle = (array: string[]) => {
+const shuffle = (array: I_Question[]) => {
   return array.sort(() => Math.random() - 0.5);
 };
-const words = shuffle(wordDummy.concat(Array(EMPTY_WORD).fill('')));
 interface WordRankProps {
   userId: number;
   track: number;
@@ -78,15 +82,28 @@ const GameWord = ({
 }) => {
   // eslint-disable-next-line no-console
   console.log(ingameRoomRes, publishIngame); //unused disable용 콘솔입니다.
+  if (ingameRoomRes && checkIsEmptyObj(ingameRoomRes)) {
+    return <div>로딩실패</div>;
+  }
+  const dummy = Array(EMPTY_WORD).fill({
+    id: Math.random() * 1001, //
+    question: ' ',
+  });
+  const words = ingameRoomRes?.questions?.concat(
+    ingameRoomRes.questions,
+    dummy
+  );
+
   return (
     <>
       <IngameHeader />
       <div className='grow'>
         <div className='flex flex-col items-center justify-around h-[60rem]'>
-          <div className='h-[25rem] grid grid-rows-[repeat(8,minmax(0,1fr))] grid-cols-[repeat(15,7rem)] text-[1.6rem] p-4 box-content bg-gray-10 rounded-2xl'>
-            {words.map((w, i) => {
-              return <WordCell key={i + w}>{w}</WordCell>;
-            })}
+          <div className='h-[25rem] grid grid-rows-[repeat(8,minmax(0,1fr))] grid-cols-[repeat(14,9rem)] text-[1.6rem] p-4 box-content bg-gray-10 rounded-2xl'>
+            {words &&
+              shuffle(words).map((w, i) => {
+                return <WordCell key={i}>{w.question}</WordCell>;
+              })}
           </div>
           <div className='flex flex-row items-end w-10/12 h-[30rem] mt-4'>
             <Dashboard

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -66,7 +66,7 @@ const GameWord = ({
   publishIngame: (destination: string, payload: PayloadType) => void;
 }) => {
   const { register, handleSubmit, setValue, getValues } = useForm();
-  const { wordsStore, setWordStore, setSubmittedWord } = useWordsStore();
+  const { wordsStore, setWordsStore, setSubmittedWord } = useWordsStore();
 
   useEffect(() => {
     if (ingameRoomRes.submittedWord) {
@@ -84,7 +84,7 @@ const GameWord = ({
     for (const idx in ingameRoomRes.questions) {
       words[ingameRoomRes.questions[Number(idx)].question] = Number(idx);
     }
-    setWordStore(words);
+    setWordsStore(words);
   }, [ingameRoomRes.questions]);
 
   return (
@@ -94,12 +94,12 @@ const GameWord = ({
         <div className='flex flex-col items-center justify-around h-[60rem]'>
           <div className='h-[25rem] grid grid-rows-[repeat(8,minmax(0,1fr))] grid-cols-[repeat(14,9rem)] text-[1.6rem] p-4 box-content bg-gray-10 rounded-2xl'>
             {!checkIsEmptyObj(wordsStore) &&
-              Object.entries(wordsStore).map((w, i) => {
+              Object.entries(wordsStore).map(([word, wordIdx], i) => {
                 return (
                   <WordCell
                     key={i}
                     randomIndex={i % 3}>
-                    {w[1] >= 0 ? w[0] : ' '}
+                    {wordIdx >= 0 ? word : ' '}
                   </WordCell>
                 );
               })}

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -77,13 +77,14 @@ const GameWord = ({
   }, [ingameRoomRes.submittedWord]);
 
   useEffect(() => {
-    if (checkIsEmptyObj(wordsStore)) {
-      const words: WordQuestionType = {};
-      for (const idx in ingameRoomRes.questions) {
-        words[ingameRoomRes.questions[Number(idx)].question] = Number(idx);
-      }
-      setWordStore(words);
+    if (!checkIsEmptyObj(wordsStore)) {
+      return;
     }
+    const words: WordQuestionType = {};
+    for (const idx in ingameRoomRes.questions) {
+      words[ingameRoomRes.questions[Number(idx)].question] = Number(idx);
+    }
+    setWordStore(words);
   }, [ingameRoomRes.questions]);
 
   return (

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -1,8 +1,8 @@
 import { ReactNode } from 'react';
+import { useForm } from 'react-hook-form';
 import Divider from '@/common/Divider/Divider';
 import Dashboard from '@/common/Ingame/Dashboard';
 import IngameHeader from '@/common/Ingame/IngameHeader';
-import Input from '@/common/Input/Input';
 import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
 import {
   I_IngameWsResponse,
@@ -82,6 +82,7 @@ const GameWord = ({
 }) => {
   // eslint-disable-next-line no-console
   console.log(ingameRoomRes, publishIngame); //unused disable용 콘솔입니다.
+  const { register, handleSubmit, setValue, getValues } = useForm();
   if (ingameRoomRes && checkIsEmptyObj(ingameRoomRes)) {
     return <div>로딩실패</div>;
   }
@@ -125,7 +126,16 @@ const GameWord = ({
                   );
                 })}
               </div>
-              <Input whSize={`w-[20rem] h-[4rem]`} />
+              <form
+                onSubmit={handleSubmit(() => {
+                  publishIngame('/word-info', { word: getValues('wordInput') });
+                  setValue('wordInput', '');
+                })}>
+                <input
+                  {...register('wordInput')}
+                  className='w-[20rem] h-[4rem] flex items-center pl-[1.75rem] rounded-2xl bg-white border-2 border-green-100 my-4 outline-0 text-gray-300 tracking-wider box-border'
+                />
+              </form>
             </div>
             <Dashboard
               type='accuracy'

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -98,7 +98,7 @@ const GameWord = ({
                 return (
                   <WordCell
                     key={i}
-                    rd={i % 3}>
+                    randomIndex={i % 3}>
                     {w[1] >= 0 ? w[0] : ' '}
                   </WordCell>
                 );

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -85,20 +85,15 @@ const GameWord = ({
     }
   }, [ingameRoomRes.submittedWord]);
 
-  if (
-    !ingameRoomRes.questions ||
-    (ingameRoomRes && checkIsEmptyObj(ingameRoomRes))
-  ) {
-    return <div>로딩실패</div>;
-  }
-
-  if (checkIsEmptyObj(wordsStore)) {
-    const words: WordQuestionType = {};
-    for (const idx in ingameRoomRes.questions) {
-      words[ingameRoomRes.questions[idx].question] = Number(idx);
+  useEffect(() => {
+    if (checkIsEmptyObj(wordsStore)) {
+      const words: WordQuestionType = {};
+      for (const idx in ingameRoomRes.questions) {
+        words[ingameRoomRes.questions[Number(idx)].question] = Number(idx);
+      }
+      setWordStore(words);
     }
-    setWordStore(words);
-  }
+  }, [ingameRoomRes.questions]);
 
   return (
     <>

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import Divider from '@/common/Divider/Divider';
 import Dashboard from '@/common/Ingame/Dashboard';
@@ -6,19 +6,10 @@ import IngameHeader from '@/common/Ingame/IngameHeader';
 import useWordsStore from '@/store/useWordsStore';
 import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
 import { I_IngameWsResponse, PayloadType } from '../types/websocketType';
+import WordCell from './WordCell';
 import { wordRankDummy } from './wordDummy';
 
 export type WordQuestionType = { [key: string]: number };
-const positions = ['center', 'left', 'right'];
-const WordCell = ({ children }: { children: ReactNode }) => {
-  const random = positions[Math.floor(Math.random() * positions.length)];
-  return (
-    <span
-      className={`p-1 text-${random} ${Math.round(Math.random()) && 'mt-auto'} ${Math.round(Math.random()) && 'mb-auto'}`}>
-      {children}
-    </span>
-  );
-};
 
 interface WordRankProps {
   userId: number;
@@ -103,7 +94,13 @@ const GameWord = ({
           <div className='h-[25rem] grid grid-rows-[repeat(8,minmax(0,1fr))] grid-cols-[repeat(14,9rem)] text-[1.6rem] p-4 box-content bg-gray-10 rounded-2xl'>
             {!checkIsEmptyObj(wordsStore) &&
               Object.entries(wordsStore).map((w, i) => {
-                return <WordCell key={i}>{w[1] >= 0 ? w[0] : ' '}</WordCell>;
+                return (
+                  <WordCell
+                    key={i}
+                    rd={i % 3}>
+                    {w[1] >= 0 ? w[0] : ' '}
+                  </WordCell>
+                );
               })}
           </div>
           <div className='flex flex-row items-end w-10/12 h-[30rem] mt-4'>

--- a/src/pages/GamePage/GameWord/WordCell.tsx
+++ b/src/pages/GamePage/GameWord/WordCell.tsx
@@ -2,9 +2,15 @@ import { ReactNode } from 'react';
 
 const positions = ['center', 'left', 'right'];
 const margins = ['mt-auto', 'mb-auto'];
-const WordCell = ({ rd, children }: { rd: number; children: ReactNode }) => {
-  const randomPosition = positions[rd];
-  const randomMargin = margins[rd % 2];
+const WordCell = ({
+  randomIndex,
+  children,
+}: {
+  randomIndex: number;
+  children: ReactNode;
+}) => {
+  const randomPosition = positions[randomIndex];
+  const randomMargin = margins[randomIndex % 2];
   return (
     <span className={`p-1 text-${randomPosition} ${randomMargin}`}>
       {children}

--- a/src/pages/GamePage/GameWord/WordCell.tsx
+++ b/src/pages/GamePage/GameWord/WordCell.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 
 const positions = ['center', 'left', 'right'];
 const margins = ['mt-auto', 'mb-auto'];
+
 const WordCell = ({
   randomIndex,
   children,

--- a/src/pages/GamePage/GameWord/WordCell.tsx
+++ b/src/pages/GamePage/GameWord/WordCell.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react';
+
+const positions = ['center', 'left', 'right'];
+const margins = ['mt-auto', 'mb-auto'];
+const WordCell = ({ rd, children }: { rd: number; children: ReactNode }) => {
+  const randomPosition = positions[rd];
+  const randomMargin = margins[rd % 2];
+  return (
+    <span className={`p-1 text-${randomPosition} ${randomMargin}`}>
+      {children}
+    </span>
+  );
+};
+export default WordCell;

--- a/src/pages/GamePage/IngameWSErrorBoundary.tsx
+++ b/src/pages/GamePage/IngameWSErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import useRoomInfoStore from '@/store/useRoomInfoStore';
 import WsError from './common/WsError';
-import useIngameWebsocket, { PayloadType } from './hooks/useIngameWebsocket';
+import useIngameWebsocket from './hooks/useIngameWebsocket';
 import { I_IngameWsResponse } from './types/websocketType';
 import { PayloadType } from './types/websocketType';
 

--- a/src/pages/GamePage/IngameWSErrorBoundary.tsx
+++ b/src/pages/GamePage/IngameWSErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import useRoomInfoStore from '@/store/useRoomInfoStore';
 import WsError from './common/WsError';
-import useIngameWebsocket from './hooks/useIngameWebsocket';
+import useIngameWebsocket, { PayloadType } from './hooks/useIngameWebsocket';
 import { I_IngameWsResponse } from './types/websocketType';
 import { PayloadType } from './types/websocketType';
 

--- a/src/pages/GamePage/common/DisconnectModal.tsx
+++ b/src/pages/GamePage/common/DisconnectModal.tsx
@@ -1,15 +1,16 @@
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
+import { useNavigate } from 'react-router-dom';
 
 interface DisconnectModalProps {
   isOpen: boolean;
-  handleClickAction: () => void;
   handleClickCancel: () => void;
 }
 const DisconnectModal = ({
   isOpen,
-  handleClickAction,
   handleClickCancel,
 }: DisconnectModalProps) => {
+  const navigate = useNavigate();
+
   return (
     <AlertDialog.Root open={isOpen}>
       <AlertDialog.Trigger asChild></AlertDialog.Trigger>
@@ -32,7 +33,10 @@ const DisconnectModal = ({
             </AlertDialog.Cancel>
             <AlertDialog.Action asChild>
               <button
-                onClick={handleClickAction}
+                onClick={() => {
+                  navigate('/main', { replace: true });
+                  navigate(0);
+                }}
                 className='text-red11 bg-red4 hover:bg-red5 focus:shadow-red7 inline-flex h-[35px] items-center justify-center rounded-[4px] px-[15px] font-medium leading-none outline-none focus:shadow-[0_0_0_2px]'>
                 네, 나갈래요
               </button>

--- a/src/pages/GamePage/types/websocketType.ts
+++ b/src/pages/GamePage/types/websocketType.ts
@@ -49,7 +49,6 @@ export interface I_IngameWsResponse {
   questions?: I_Question[];
 }
 export interface I_Question {
-  id: number;
   question: string;
 }
 export type IngameMessageType =

--- a/src/store/useWordsStore.ts
+++ b/src/store/useWordsStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+interface I_UseWordsStore {
+  wordsStore: object;
+  setWords: (wordsAll: object) => void;
+  setWordUsed: (word: object) => void;
+}
+
+const useWordsStore = create<I_UseWordsStore>((set) => ({
+  wordsStore: {},
+  setWords: (wordsAll: object) => set({ wordsStore: wordsAll }),
+  setWordUsed: (word: object) =>
+    set((state) => ({ wordsStore: { ...state.wordsStore, ...word } })),
+}));
+// interface I_UseWordsStore {
+//   wordsStore: Map<string, number>;
+//   setWords: (wordsAll: Map<string, number>) => void;
+//   setWordUsed: (word: object) => void;
+// }
+
+// const useWordsStore = create<I_UseWordsStore>((set) => ({
+//   wordsStore: new Map(),
+//   setWords: (wordsAll: Map<string, number>) => set({ wordsStore: wordsAll }),
+//   setWordUsed: (word: object) =>
+//     set((state) => ({ wordsStore: { ...state.wordsStore, ...word } })),
+// }));
+
+export default useWordsStore;

--- a/src/store/useWordsStore.ts
+++ b/src/store/useWordsStore.ts
@@ -3,13 +3,13 @@ import { WordQuestionType } from '@/pages/GamePage/GameWord/GameWord';
 
 interface I_UseWordsStore {
   wordsStore: WordQuestionType;
-  setWordStore: (wordsAll: WordQuestionType) => void;
+  setWordsStore: (wordsAll: WordQuestionType) => void;
   setSubmittedWord: (word: WordQuestionType) => void;
 }
 
 const useWordsStore = create<I_UseWordsStore>((set) => ({
   wordsStore: {},
-  setWordStore: (wordsAll: WordQuestionType) => set({ wordsStore: wordsAll }),
+  setWordsStore: (wordsAll: WordQuestionType) => set({ wordsStore: wordsAll }),
   setSubmittedWord: (word: WordQuestionType) =>
     set((state) => ({ wordsStore: { ...state.wordsStore, ...word } })),
 }));

--- a/src/store/useWordsStore.ts
+++ b/src/store/useWordsStore.ts
@@ -1,15 +1,16 @@
 import { create } from 'zustand';
+import { WordQuestionType } from '@/pages/GamePage/GameWord/GameWord';
 
 interface I_UseWordsStore {
-  wordsStore: object;
-  setWords: (wordsAll: object) => void;
-  setWordUsed: (word: object) => void;
+  wordsStore: WordQuestionType;
+  setWordStore: (wordsAll: WordQuestionType) => void;
+  setSubmittedWord: (word: WordQuestionType) => void;
 }
 
 const useWordsStore = create<I_UseWordsStore>((set) => ({
   wordsStore: {},
-  setWords: (wordsAll: object) => set({ wordsStore: wordsAll }),
-  setWordUsed: (word: object) =>
+  setWordStore: (wordsAll: WordQuestionType) => set({ wordsStore: wordsAll }),
+  setSubmittedWord: (word: WordQuestionType) =>
     set((state) => ({ wordsStore: { ...state.wordsStore, ...word } })),
 }));
 

--- a/src/store/useWordsStore.ts
+++ b/src/store/useWordsStore.ts
@@ -12,17 +12,5 @@ const useWordsStore = create<I_UseWordsStore>((set) => ({
   setWordUsed: (word: object) =>
     set((state) => ({ wordsStore: { ...state.wordsStore, ...word } })),
 }));
-// interface I_UseWordsStore {
-//   wordsStore: Map<string, number>;
-//   setWords: (wordsAll: Map<string, number>) => void;
-//   setWordUsed: (word: object) => void;
-// }
-
-// const useWordsStore = create<I_UseWordsStore>((set) => ({
-//   wordsStore: new Map(),
-//   setWords: (wordsAll: Map<string, number>) => set({ wordsStore: wordsAll }),
-//   setWordUsed: (word: object) =>
-//     set((state) => ({ wordsStore: { ...state.wordsStore, ...word } })),
-// }));
 
 export default useWordsStore;


### PR DESCRIPTION
## 📋 Issue Number
close #

## 💻 구현 내용
- ingameRoomRes.questions로 100개의 단어를 보여줍니다. store에 저장합니다.
- 존재하는 단어 입력시 발행하고. 모든 참여자는 INFO타입 메세지를 받습니다.
- INFO타입 메세지의 submittedWord로부터 store를 갱신합니다.

## 📷 Screenshots

https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/81412212/fabc2821-d7d0-4f8e-9b8c-508e8c3cbc4b


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
* 이외 단어게임 진행로직 상에 필요한 부분들이 더 있을까요?
 
 <!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
