### PR TITLE
[Feat] 인게임 - 단어 대시보드 연결 값 수정

### DIFF
--- a/src/common/Ingame/Dashboard.tsx
+++ b/src/common/Ingame/Dashboard.tsx
@@ -29,7 +29,6 @@ const Dashboard = ({ type, value }: DashboardProps) => {
     <>
       <div>
         <div className='w-[24rem] h-[12rem] p-8 box-border rounded-[12rem_12rem_0_0] dashboardStyle'>
-          {/* <div className='w-[24rem] h-[12rem] p-8 bg-gradient-radial bg-origin-content'> */}
           <img
             src={needle}
             alt='계기판'

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -3,9 +3,9 @@ import { Navigate, useNavigate } from 'react-router-dom';
 import { useAuthCheck } from '@/hooks/useAuth';
 import useRoomInfoStore from '@/store/useRoomInfoStore';
 import WsError from './common/WsError';
-import GameSentence from './GameSentence/GameSentence';
 // import GameCode from './GameCode/GameCode';
 import GameWaitingRoom from './GameWaitingRoom/GameWaitingRoom';
+import GameWord from './GameWord/GameWord';
 // import GameWord from './GameWord/GameWord';
 import useWebsocket from './hooks/useWebsocket';
 import { IngameWSErrorBoundary } from './IngameWSErrorBoundary';
@@ -95,7 +95,7 @@ const GamePage = () => {
         {({ ingameRoomRes, publishIngame }) => (
           <>
             {
-              <GameSentence
+              <GameWord
                 ingameRoomRes={ingameRoomRes}
                 publishIngame={publishIngame}
                 userId={userId}

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -3,10 +3,13 @@ import { Navigate, useNavigate } from 'react-router-dom';
 import { useAuthCheck } from '@/hooks/useAuth';
 import useRoomInfoStore from '@/store/useRoomInfoStore';
 import WsError from './common/WsError';
-// import GameCode from './GameCode/GameCode';
+// eslint-disable-next-line unused-imports/no-unused-imports, @typescript-eslint/no-unused-vars
+import GameCode from './GameCode/GameCode';
+// eslint-disable-next-line unused-imports/no-unused-imports, @typescript-eslint/no-unused-vars
+import GameSentence from './GameSentence/GameSentence';
 import GameWaitingRoom from './GameWaitingRoom/GameWaitingRoom';
+// eslint-disable-next-line unused-imports/no-unused-imports, @typescript-eslint/no-unused-vars
 import GameWord from './GameWord/GameWord';
-// import GameWord from './GameWord/GameWord';
 import useWebsocket from './hooks/useWebsocket';
 import { IngameWSErrorBoundary } from './IngameWSErrorBoundary';
 

--- a/src/pages/GamePage/GameSentence/useTypingState.tsx
+++ b/src/pages/GamePage/GameSentence/useTypingState.tsx
@@ -17,7 +17,7 @@ const useTypingState = () => {
   };
 
   const onInputChange = useCallback(
-    (totalCharCompleted: number, totalChar: number) => {
+    (totalCharCompleted: number, totalChar: number, TYPING_CONTANT = 200) => {
       if (!startTime) {
         startTyping();
         return;
@@ -28,7 +28,7 @@ const useTypingState = () => {
         (endTime.getTime() - startTime.getTime()) / 1000;
 
       let calculatedTypingSpeed =
-        (totalCharCompleted / elapsedTimeInSeconds) * 200;
+        (totalCharCompleted / elapsedTimeInSeconds) * TYPING_CONTANT;
       let calculatedAccuracy = (totalCharCompleted / totalChar) * 100;
 
       calculatedTypingSpeed = Number.isNaN(calculatedTypingSpeed)

--- a/src/pages/GamePage/GameSentence/useTypingState.tsx
+++ b/src/pages/GamePage/GameSentence/useTypingState.tsx
@@ -57,12 +57,10 @@ const useTypingState = () => {
     [onInputChange]
   );
 
-  const initializeTyping = useCallback((isWord?: boolean) => {
+  const initializeTyping = useCallback(() => {
     setStartTime(null);
     setCpm(0);
-    if (!isWord) {
-      setAccurate(0);
-    }
+    setAccurate(0);
   }, []);
 
   return {

--- a/src/pages/GamePage/GameSentence/useTypingState.tsx
+++ b/src/pages/GamePage/GameSentence/useTypingState.tsx
@@ -57,10 +57,12 @@ const useTypingState = () => {
     [onInputChange]
   );
 
-  const initializeTyping = useCallback(() => {
+  const initializeTyping = useCallback((isWord?: boolean) => {
     setStartTime(null);
     setCpm(0);
-    setAccurate(0);
+    if (!isWord) {
+      setAccurate(0);
+    }
   }, []);
 
   return {

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -1,4 +1,5 @@
 import IngameHeader from '@/common/Ingame/IngameHeader';
+import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
 import { InagmeWsChildrenProps } from '../IngameWSErrorBoundary';
 import GameWordContainer from './GameWordContainer';
 
@@ -12,11 +13,13 @@ const GameWord = ({ ingameRoomRes, publishIngame, userId }: GameWordProps) => {
       <IngameHeader />
       <div className='grow'>
         <div className='flex flex-col items-center justify-between h-[61rem]'>
-          <GameWordContainer
-            ingameRoomRes={ingameRoomRes}
-            publishIngame={publishIngame}
-            userId={userId}
-          />
+          {!checkIsEmptyObj(ingameRoomRes) && (
+            <GameWordContainer
+              ingameRoomRes={ingameRoomRes}
+              publishIngame={publishIngame}
+              userId={userId}
+            />
+          )}
         </div>
       </div>
     </>

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -1,7 +1,7 @@
 import IngameHeader from '@/common/Ingame/IngameHeader';
 import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
 import { InagmeWsChildrenProps } from '../IngameWSErrorBoundary';
-import GameWordContainer from './GameWordContainer';
+import WordGameLayout from './WordGameLayout';
 
 interface GameWordProps extends InagmeWsChildrenProps {
   userId: number;
@@ -14,7 +14,7 @@ const GameWord = ({ ingameRoomRes, publishIngame, userId }: GameWordProps) => {
       <div className='grow'>
         <div className='flex flex-col items-center justify-between h-[61rem]'>
           {!checkIsEmptyObj(ingameRoomRes) && (
-            <GameWordContainer
+            <WordGameLayout
               ingameRoomRes={ingameRoomRes}
               publishIngame={publishIngame}
               userId={userId}

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import Dashboard from '@/common/Ingame/Dashboard';
 import IngameHeader from '@/common/Ingame/IngameHeader';
@@ -6,20 +5,12 @@ import { InagmeWsChildrenProps } from '../IngameWSErrorBoundary';
 import WordCell from './WordCell';
 import WordRankContainer from './WordRankContainer';
 
-export type WordQuestionType = { [key: string]: number };
 interface GameWordProps extends InagmeWsChildrenProps {
   userId: number;
 }
 
 const GameWord = ({ ingameRoomRes, publishIngame, userId }: GameWordProps) => {
   const { register, handleSubmit, setValue, getValues } = useForm();
-
-  useEffect(() => {
-    if (ingameRoomRes.submittedWord) {
-      const submittedWord: WordQuestionType = {};
-      submittedWord[ingameRoomRes.submittedWord] = -1;
-    }
-  }, [ingameRoomRes.submittedWord]);
 
   return (
     <>
@@ -46,15 +37,9 @@ const GameWord = ({ ingameRoomRes, publishIngame, userId }: GameWordProps) => {
             />
             <div className='flex flex-col grow items-center'>
               <div className='grow flex relative w-full justify-center'>
-                {ingameRoomRes.gameScore && (
-                  <WordRankContainer
-                    gameScore={ingameRoomRes.gameScore}
-                    userId={userId}
-                  />
-                )}
                 {ingameRoomRes.allMembers && (
                   <WordRankContainer
-                    gameScore={ingameRoomRes.allMembers}
+                    allMembers={ingameRoomRes.allMembers}
                     userId={userId}
                   />
                 )}

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -1,68 +1,22 @@
-import { useForm } from 'react-hook-form';
-import Dashboard from '@/common/Ingame/Dashboard';
 import IngameHeader from '@/common/Ingame/IngameHeader';
 import { InagmeWsChildrenProps } from '../IngameWSErrorBoundary';
-import WordCell from './WordCell';
-import WordRankContainer from './WordRankContainer';
+import GameWordContainer from './GameWordContainer';
 
 interface GameWordProps extends InagmeWsChildrenProps {
   userId: number;
 }
 
 const GameWord = ({ ingameRoomRes, publishIngame, userId }: GameWordProps) => {
-  const { register, handleSubmit, setValue, getValues } = useForm();
-
   return (
     <>
       <IngameHeader />
       <div className='grow'>
-        <div className='flex flex-col items-center justify-between h-[60rem]'>
-          <div className='h-[27rem] grid grid-rows-[repeat(8,minmax(0,1fr))] grid-cols-[repeat(14,9rem)] text-[1.6rem] p-4 box-content bg-gray-10 rounded-2xl'>
-            {ingameRoomRes.questions?.map((questionObj, i) => {
-              return (
-                <WordCell
-                  key={i}
-                  randomIndex={i % 3}>
-                  {questionObj.question.startsWith('#')
-                    ? ' '
-                    : questionObj.question}
-                </WordCell>
-              );
-            })}
-          </div>
-          <div className='flex flex-row items-end w-10/12 h-[30rem] mt-4'>
-            <Dashboard
-              type='cpm'
-              value={300}
-            />
-            <div className='flex flex-col grow items-center'>
-              <div className='grow flex relative w-full justify-center'>
-                {ingameRoomRes.allMembers && (
-                  <WordRankContainer
-                    allMembers={ingameRoomRes.allMembers}
-                    userId={userId}
-                  />
-                )}
-              </div>
-              <form
-                onSubmit={handleSubmit(() => {
-                  publishIngame('/word-info', { word: getValues('wordInput') });
-                  setValue('wordInput', '');
-                })}>
-                <input
-                  autoFocus
-                  autoComplete='off'
-                  onPaste={(e) => e.preventDefault()}
-                  {...register('wordInput')}
-                  className='w-[20rem] h-[4rem] flex items-center pl-[1.75rem] rounded-2xl bg-white border-2 border-green-100 my-4 outline-0 text-gray-300 tracking-wider box-border'
-                />
-              </form>
-            </div>
-            <Dashboard
-              type='accuracy'
-              value={300}
-            />
-          </div>
+        <div className='flex flex-col items-center justify-between h-[61rem]'>
+          <GameWordContainer
+            ingameRoomRes={ingameRoomRes}
+            publishIngame={publishIngame}
+            userId={userId}
+          />
         </div>
       </div>
     </>

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -2,21 +2,16 @@ import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import Dashboard from '@/common/Ingame/Dashboard';
 import IngameHeader from '@/common/Ingame/IngameHeader';
-import { I_IngameWsResponse, PayloadType } from '../types/websocketType';
+import { InagmeWsChildrenProps } from '../IngameWSErrorBoundary';
 import WordCell from './WordCell';
 import WordRankContainer from './WordRankContainer';
 
 export type WordQuestionType = { [key: string]: number };
-
-const GameWord = ({
-  ingameRoomRes,
-  publishIngame,
-  userId,
-}: {
-  ingameRoomRes: I_IngameWsResponse;
-  publishIngame: (destination: string, payload: PayloadType) => void;
+interface GameWordProps extends InagmeWsChildrenProps {
   userId: number;
-}) => {
+}
+
+const GameWord = ({ ingameRoomRes, publishIngame, userId }: GameWordProps) => {
   const { register, handleSubmit, setValue, getValues } = useForm();
 
   useEffect(() => {
@@ -46,7 +41,7 @@ const GameWord = ({
           </div>
           <div className='flex flex-row items-end w-10/12 h-[30rem] mt-4'>
             <Dashboard
-              type='wpm'
+              type='cpm'
               value={300}
             />
             <div className='flex flex-col grow items-center'>

--- a/src/pages/GamePage/GameWord/GameWordContainer.tsx
+++ b/src/pages/GamePage/GameWord/GameWordContainer.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+import Dashboard from '@/common/Ingame/Dashboard';
+import useTypingState from '../GameSentence/useTypingState';
+import { InagmeWsChildrenProps } from '../IngameWSErrorBoundary';
+import WordCell from './WordCell';
+import WordRankContainer from './WordRankContainer';
+
+interface GameWordProps extends InagmeWsChildrenProps {
+  userId: number;
+}
+
+const GameWordContainer = ({
+  ingameRoomRes,
+  publishIngame,
+  userId,
+}: GameWordProps) => {
+  const { register, handleSubmit, setValue, getValues } = useForm();
+  const { cpm, onInputChange, initializeTyping } = useTypingState();
+
+  const submitCount = useRef(0);
+  const approvedSubmitCount = useRef(0);
+
+  useEffect(() => {
+    if (ingameRoomRes.submitMemberId === userId) {
+      approvedSubmitCount.current += 1;
+    }
+    onInputChange(0, 100); //동기화..
+  }, [ingameRoomRes]);
+
+  return (
+    <>
+      <div className='h-[27rem] grid grid-rows-[repeat(8,minmax(0,1fr))] grid-cols-[repeat(14,9rem)] text-[1.6rem] p-4 box-content bg-gray-10 rounded-2xl'>
+        {ingameRoomRes.questions?.map((questionObj, i) => {
+          return (
+            <WordCell
+              key={i}
+              randomIndex={i % 3}>
+              {questionObj.question.startsWith('#')
+                ? ' '
+                : questionObj.question}
+            </WordCell>
+          );
+        })}
+      </div>
+      <div className='flex flex-row items-end w-10/12 h-[30rem] mt-4'>
+        <Dashboard
+          type='cpm'
+          value={cpm}
+        />
+        <div className='flex flex-col grow items-center'>
+          <div className='grow flex relative w-full justify-center'>
+            {ingameRoomRes.allMembers && (
+              <WordRankContainer
+                allMembers={ingameRoomRes.allMembers}
+                userId={userId}
+              />
+            )}
+          </div>
+          <form
+            onSubmit={handleSubmit(() => {
+              publishIngame('/word-info', { word: getValues('wordInput') });
+              setValue('wordInput', '');
+              initializeTyping(true);
+              submitCount.current += 1;
+            })}>
+            <input
+              autoFocus
+              autoComplete='off'
+              onPaste={(e) => e.preventDefault()}
+              {...register('wordInput', {
+                onChange: (e) =>
+                  onInputChange(
+                    e.target.value.trim().length,
+                    100 // 단어게임에선 totalChar가 없습니다
+                  ),
+              })}
+              className='w-[20rem] h-[4rem] flex items-center pl-[1.75rem] rounded-2xl bg-white border-2 border-green-100 my-4 outline-0 text-gray-300 tracking-wider box-border'
+            />
+          </form>
+        </div>
+        <Dashboard
+          type='accuracy'
+          value={
+            Math.floor(
+              (approvedSubmitCount.current / submitCount.current) * 100
+            ) || 0
+          }
+        />
+      </div>
+    </>
+  );
+};
+export default GameWordContainer;

--- a/src/pages/GamePage/GameWord/GameWordContainer.tsx
+++ b/src/pages/GamePage/GameWord/GameWordContainer.tsx
@@ -61,7 +61,7 @@ const GameWordContainer = ({
             onSubmit={handleSubmit(() => {
               publishIngame('/word-info', { word: getValues('wordInput') });
               setValue('wordInput', '');
-              initializeTyping(true);
+              initializeTyping();
               submitCount.current += 1;
             })}>
             <input
@@ -70,10 +70,7 @@ const GameWordContainer = ({
               onPaste={(e) => e.preventDefault()}
               {...register('wordInput', {
                 onChange: (e) =>
-                  onInputChange(
-                    e.target.value.trim().length,
-                    100 // 단어게임에선 totalChar가 없습니다
-                  ),
+                  onInputChange(e.target.value.trim().length, 100), // 단어게임에선 totalChar가 없습니다
               })}
               className='w-[20rem] h-[4rem] flex items-center pl-[1.75rem] rounded-2xl bg-white border-2 border-green-100 my-4 outline-0 text-gray-300 tracking-wider box-border'
             />

--- a/src/pages/GamePage/GameWord/GameWordContainer.tsx
+++ b/src/pages/GamePage/GameWord/GameWordContainer.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import Dashboard from '@/common/Ingame/Dashboard';
-import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
 import useTypingState from '../GameSentence/useTypingState';
 import { InagmeWsChildrenProps } from '../IngameWSErrorBoundary';
 import WordCell from './WordCell';
@@ -21,7 +20,6 @@ const GameWordContainer = ({
 
   const submitCount = useRef(0);
   const approvedSubmitCount = useRef(0);
-
   useEffect(() => {
     if (ingameRoomRes.submitMemberId === userId) {
       approvedSubmitCount.current += 1;
@@ -51,12 +49,10 @@ const GameWordContainer = ({
         />
         <div className='flex flex-col grow items-center'>
           <div className='grow flex relative w-full justify-center'>
-            {!checkIsEmptyObj(ingameRoomRes) && (
-              <WordRankContainer
-                allMembers={ingameRoomRes.allMembers}
-                userId={userId}
-              />
-            )}
+            <WordRankContainer
+              allMembers={ingameRoomRes.allMembers}
+              userId={userId}
+            />
           </div>
           <form
             onSubmit={handleSubmit(() => {

--- a/src/pages/GamePage/GameWord/GameWordContainer.tsx
+++ b/src/pages/GamePage/GameWord/GameWordContainer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import Dashboard from '@/common/Ingame/Dashboard';
+import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
 import useTypingState from '../GameSentence/useTypingState';
 import { InagmeWsChildrenProps } from '../IngameWSErrorBoundary';
 import WordCell from './WordCell';
@@ -50,7 +51,7 @@ const GameWordContainer = ({
         />
         <div className='flex flex-col grow items-center'>
           <div className='grow flex relative w-full justify-center'>
-            {ingameRoomRes.allMembers && (
+            {!checkIsEmptyObj(ingameRoomRes) && (
               <WordRankContainer
                 allMembers={ingameRoomRes.allMembers}
                 userId={userId}

--- a/src/pages/GamePage/GameWord/WordGameLayout.tsx
+++ b/src/pages/GamePage/GameWord/WordGameLayout.tsx
@@ -10,7 +10,7 @@ interface GameWordProps extends InagmeWsChildrenProps {
   userId: number;
 }
 
-const GameWordContainer = ({
+const WordGameLayout = ({
   ingameRoomRes,
   publishIngame,
   userId,
@@ -24,7 +24,7 @@ const GameWordContainer = ({
     if (ingameRoomRes.submitMemberId === userId) {
       approvedSubmitCount.current += 1;
     }
-    onInputChange(0, 100); //동기화..
+    onInputChange(0, 100, 150); //동기화..
   }, [ingameRoomRes]);
 
   return (
@@ -67,7 +67,7 @@ const GameWordContainer = ({
               onPaste={(e) => e.preventDefault()}
               {...register('wordInput', {
                 onChange: (e) =>
-                  onInputChange(e.target.value.trim().length, 100), // 단어게임에선 totalChar가 없습니다
+                  onInputChange(e.target.value.trim().length, 100, 150), // 단어게임에선 totalChar가 없습니다
               })}
               className='w-[20rem] h-[4rem] flex items-center pl-[1.75rem] rounded-2xl bg-white border-2 border-green-100 my-4 outline-0 text-gray-300 tracking-wider box-border'
             />
@@ -85,4 +85,4 @@ const GameWordContainer = ({
     </>
   );
 };
-export default GameWordContainer;
+export default WordGameLayout;

--- a/src/pages/GamePage/GameWord/WordGameLayout.tsx
+++ b/src/pages/GamePage/GameWord/WordGameLayout.tsx
@@ -19,11 +19,11 @@ const WordGameLayout = ({
   const { cpm, onInputChange, initializeTyping } = useTypingState();
 
   const submitCount = useRef(0);
-  const approvedSubmitCount = useRef(0);
+  const currentScore =
+    ingameRoomRes.allMembers.find(({ memberId }) => memberId === userId)
+      ?.score ?? 0;
+
   useEffect(() => {
-    if (ingameRoomRes.submitMemberId === userId) {
-      approvedSubmitCount.current += 1;
-    }
     onInputChange(0, 100, 150); //동기화..
   }, [ingameRoomRes]);
 
@@ -75,11 +75,7 @@ const WordGameLayout = ({
         </div>
         <Dashboard
           type='accuracy'
-          value={
-            Math.floor(
-              (approvedSubmitCount.current / submitCount.current) * 100
-            ) || 0
-          }
+          value={Math.floor((currentScore / submitCount.current) * 100) || 0}
         />
       </div>
     </>

--- a/src/pages/GamePage/GameWord/WordRankContainer.tsx
+++ b/src/pages/GamePage/GameWord/WordRankContainer.tsx
@@ -1,36 +1,19 @@
-import { Fragment, useRef } from 'react';
+import { Fragment } from 'react';
 import Divider from '@/common/Divider/Divider';
-import { GameScoreType, I_AllMember } from '../types/websocketType';
+import { I_AllMember } from '../types/websocketType';
 import WordRankTrack from './WordRankTrack';
 
-export type WordQuestionType = { [key: string]: number };
-
 const WordRankContainer = ({
-  gameScore,
+  allMembers,
   userId,
 }: {
-  gameScore: GameScoreType | I_AllMember[];
+  allMembers: I_AllMember[];
   userId: number;
 }) => {
-  function isTypeAllMembers(
-    gameScore: GameScoreType | I_AllMember[]
-  ): gameScore is I_AllMember[] {
-    return gameScore.length > 0;
-  }
-  const trackList = useRef<{ [key: string]: number }>();
-  if (isTypeAllMembers(gameScore)) {
-    // I_AllMember[] 인 경우 정제하여 GameScoreType 형태의 값으로 만든 후 렌더하도록합니다
-    const scoreFromMembers: { [key: string]: number } = {};
-    for (const member of gameScore) {
-      scoreFromMembers[member.memberId.toString()] = 0;
-    }
-    trackList.current = scoreFromMembers;
-  }
-  const rankData = trackList.current || gameScore;
-
   return (
     <>
-      {Object.entries(rankData).map(([memberId, score], i) => {
+      {allMembers.map((member, i) => {
+        const { memberId, score } = member;
         return (
           <Fragment key={i}>
             <div className={'h-[24rem] flex justify-between'}>
@@ -51,7 +34,7 @@ const WordRankContainer = ({
                 isMe={userId === Number(memberId)}
                 score={score}
               />
-              {i === Object.entries(gameScore).length - 1 && (
+              {i === allMembers.length - 1 && (
                 <Divider
                   orientation='vertical'
                   className='border-r-[.2rem]'

--- a/src/pages/GamePage/types/websocketType.ts
+++ b/src/pages/GamePage/types/websocketType.ts
@@ -33,6 +33,7 @@ export interface I_AllMember {
   nickname: string;
   ranking: number;
   readyStatus: boolean;
+  score: number;
 }
 
 export type HandlePubReadyGameType = () => void;
@@ -45,7 +46,7 @@ export interface I_IngameWsResponse {
   submittedWord?: string;
   submitMemberId?: number;
   gameScore?: GameScoreType;
-  allMembers?: I_AllMember[];
+  allMembers: I_AllMember[];
   questions?: I_Question[];
 }
 export interface I_Question {


### PR DESCRIPTION
## 📋 Issue Number
close #135 

## 💻 구현 내용

- 단어게임에서 타수는 `현재 입력창에 입력한 글자 수 / 경과시간` 입니다.
- 단어게임에서 정확도는 `성공한 발행(단어입력후submit) 수 / 전체 발행 수`입니다.

## 📷 Screenshots

https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/81412212/ea3bf1af-d7f8-4ea4-bc64-720c19f28b93



## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->

* useTypingState의  onInputChange 프롭스인 totalChar 타입선언을 변경하지 않으려고, [단어 입력 Input의 onChange에선]() 임의로 100이라는 값을 인자로 넘기고 있습니다. 다른 방법이 있을까요?
* 타수, 정확도 계산에 더 나은 수식이 있다면 알려주세요!
* calculatedTypingSpeed 계산에 **200**을 곱하는 수식이다 보니 1 ~2초안에 4 ~6글자를 치는 단어게임에선 몇천타까지 나올수가 있네요..
* 타수나 정확도 부분에 이슈 확인되시면 알려주세요

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
