### PR TITLE
[Feat] 인게임 코드 - 마무리

### DIFF
--- a/src/common/Ingame/IngameHeader.tsx
+++ b/src/common/Ingame/IngameHeader.tsx
@@ -28,6 +28,7 @@ const IngameHeader = ({
       handleRoundFinish();
     },
   });
+
   useEffect(() => {
     isNextRound && resetTimer();
   }, [isNextRound]);
@@ -53,7 +54,6 @@ const IngameHeader = ({
           </span>
         </div>
         <div className='text-[3rem]'>
-          {/* TODO: currentPlayer 대신 currentRound 필요 */}
           🏁 {currentRound} / {roomInfo?.maxRound}
         </div>
       </div>

--- a/src/pages/GamePage/GameCode/CodeContainer.tsx
+++ b/src/pages/GamePage/GameCode/CodeContainer.tsx
@@ -1,14 +1,14 @@
 import Highlight from 'react-highlight';
 
 interface CodeContainerProps {
-  dummyCode: string;
+  codeItem: string;
 }
 
-const CodeContainer = ({ dummyCode }: CodeContainerProps) => {
+const CodeContainer = ({ codeItem }: CodeContainerProps) => {
   return (
     <>
       <div className='w-[60rem] select-none'>
-        <Highlight className='javascript'>{dummyCode}</Highlight>
+        <Highlight className='javascript'>{codeItem}</Highlight>
       </div>
     </>
   );

--- a/src/pages/GamePage/GameCode/CodeFormContainer.tsx
+++ b/src/pages/GamePage/GameCode/CodeFormContainer.tsx
@@ -1,21 +1,32 @@
+import { useCallback, useState } from 'react';
 import Dashboard from '@/common/Ingame/Dashboard';
 import useTypingState from '../GameSentence/useTypingState';
+import { I_Question } from '../types/websocketType';
 import CodeContainer from './CodeContainer';
 import CodeForm from './CodeForm';
 
 interface CodeFormContainerProps {
-  dummyCode: string;
-  convertedDummyCode: string[];
+  codeList: I_Question[];
+  convertedCodeList: string[][];
   handleUpdateScore: (_isAllSubmitted: boolean) => void;
+  handleRoundFinish: () => void;
 }
 
 const CodeFormContainer = ({
-  dummyCode,
-  convertedDummyCode,
+  codeList,
+  convertedCodeList,
   handleUpdateScore,
+  handleRoundFinish,
 }: CodeFormContainerProps) => {
   const { cpm, accurate, onInputChange, onKeyDown, initializeTyping } =
     useTypingState();
+
+  const [currentProblemIndex, setCurrentProblemIndex] = useState(0);
+
+  const handleUpdateProblem = useCallback(() => {
+    setCurrentProblemIndex((prev) => prev + 1);
+  }, []);
+
   return (
     <div className='flex flex-col items-center justify-center z-10'>
       <div className='flex items-end gap-4'>
@@ -23,19 +34,29 @@ const CodeFormContainer = ({
           type='cpm'
           value={cpm}
         />
-        <CodeContainer dummyCode={dummyCode} />
+        <CodeContainer
+          codeItem={
+            currentProblemIndex === convertedCodeList.length
+              ? codeList[currentProblemIndex - 1].question
+              : codeList[currentProblemIndex].question
+          }
+        />
         <Dashboard
           type='accuracy'
           value={accurate}
         />
       </div>
       <CodeForm
-        inputName='code'
-        convertedDummyCode={convertedDummyCode}
+        key={`${codeList[0].question}${currentProblemIndex}`}
+        isLastSentence={currentProblemIndex === convertedCodeList.length - 1}
+        isRoundFinish={currentProblemIndex === convertedCodeList.length}
+        codeItem={convertedCodeList?.[currentProblemIndex] ?? []}
         handleUpdateScore={handleUpdateScore}
         onInputChange={onInputChange}
         onKeyDown={onKeyDown}
         initializeTyping={initializeTyping}
+        handleUpdateProblem={handleUpdateProblem}
+        handleRoundFinish={handleRoundFinish}
       />
     </div>
   );

--- a/src/pages/GamePage/GameCode/GameCode.tsx
+++ b/src/pages/GamePage/GameCode/GameCode.tsx
@@ -1,174 +1,115 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import car1 from '@/assets/cars/car11.png';
-import {
-  CANVAS_HEIGHT,
-  CANVAS_WIDTH,
-  CAR_DIRECTION,
-  MAX_X,
-  MAX_Y,
-  MOVE_STEP_X,
-  START_X,
-  START_Y,
-} from '@/common/Ingame/ingameConstants';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import IngameHeader from '@/common/Ingame/IngameHeader';
 import IngameRank from '@/common/Ingame/IngameRank';
-import useCanvas from '@/hooks/useCanvas';
 import CanvasTrack from '../common/CanvasTrack';
 import { InagmeWsChildrenProps } from '../IngameWSErrorBoundary';
+import { I_Question } from '../types/websocketType';
 import CodeFormContainer from './CodeFormContainer';
 
 interface GameCodeProps extends InagmeWsChildrenProps {
   userId: number;
 }
-interface I_CarCoord {
-  x: number;
-  y: number;
-}
+
+const SECONDS_PER_SENTENCE = 7;
 
 const GameCode = ({ ingameRoomRes, publishIngame, userId }: GameCodeProps) => {
-  const canvasRef = useCanvas({
-    setCanvas: (canvas: HTMLCanvasElement) => {
-      canvas.width = CANVAS_WIDTH;
-      canvas.height = CANVAS_HEIGHT;
-    },
-  });
-  const carImageRef = useRef<HTMLImageElement | null>(null);
-  const car1Ref = useRef<I_CarCoord>({ x: START_X, y: START_Y });
-  // 추후: const carsRef = useRef<I_CarCoord[]>([]);
-  const carDirRef = useRef(CAR_DIRECTION.RIGHT);
+  const codeList = useRef<I_Question[]>(ingameRoomRes.questions!);
 
-  // TODO: 추후 서버에서 전달하는 문제를 여기서 꺼내기
-  const dummyCode = `function dfs(graph, start, visited) {
-    const stack = [];
-    stack.push(start);
-    while (stack.length) {
-      let v = stack.pop();
-      if (!visited[v]) {
-        console.log(v);
-        visited[v] = true;
-        for (let node of graph[v]) {
-          if (!visited[node]) {
-            stack.push(node);
-          }
-        }
-      }
-    }
-  }`;
+  const [currentRound, setCurrentRound] = useState(1);
 
-  const convertedDummyCode = dummyCode.split('\n').map((row) => row.trim());
+  const didRoundFinishSubmitted = useRef(false);
 
-  const myCurrentScore = useRef(
-    ingameRoomRes.allMembers.find(({ memberId }) => memberId === userId)
-      ?.score ?? 0
+  const convertedCodeList = codeList.current.map(({ question }) =>
+    question.split('\n').map((code) => code.trim())
   );
+
+  const myCurrentScore = ingameRoomRes.allMembers.find(
+    ({ memberId }) => memberId === userId
+  )!.score;
 
   const totalSpacedWord = useMemo(
     () =>
-      convertedDummyCode.reduce((prev, cur) => prev + cur.split(' ').length, 0),
-    [convertedDummyCode]
+      convertedCodeList.reduce(
+        (numOfArray, currentArray) =>
+          numOfArray +
+          currentArray
+            .map((code) => code.split(' ').length)
+            .reduce((prevNum, currentNum) => prevNum + currentNum, 0),
+        0
+      ),
+    [convertedCodeList]
   );
+
   const scorePerSubmit = useMemo(
     () => Math.floor((1 / totalSpacedWord) * 100),
     [totalSpacedWord]
   );
 
-  const handleUpdateScore = (_isAllSubmitted: boolean) => {
-    myCurrentScore.current += scorePerSubmit;
-    if (_isAllSubmitted) {
-      myCurrentScore.current = 100;
-    }
-    publishIngame('/info', { currentScore: myCurrentScore.current });
-  };
-
-  const blockOverflowPos = useCallback((pos: I_CarCoord) => {
-    if (pos.x === START_X && pos.y === START_Y) {
-      clearInterval(timerForTest);
-      return;
-    }
-    if (pos.x >= MAX_X && carDirRef.current === 'right') {
-      carDirRef.current = CAR_DIRECTION.DOWN;
-    }
-    if (pos.y >= MAX_Y && carDirRef.current === 'down') {
-      carDirRef.current = CAR_DIRECTION.LEFT;
-    }
-    if (pos.x <= 0 && carDirRef.current === 'left') {
-      carDirRef.current = CAR_DIRECTION.UP;
-    }
-    if (pos.y <= 0 && carDirRef.current === 'up') {
-      carDirRef.current = CAR_DIRECTION.RIGHT;
-    }
-    pos.x = Math.max(0, Math.min(pos.x, MAX_X));
-    pos.y = Math.max(0, Math.min(pos.y, MAX_Y));
-  }, []);
-
-  const updateCarCoord = useCallback(
-    (carCoord: I_CarCoord) => {
-      const dir = carDirRef.current;
-      if (dir === 'right') {
-        carCoord.x += MOVE_STEP_X;
-      } else if (dir === 'down') {
-        carCoord.y += MOVE_STEP_X;
-      } else if (dir === 'left') {
-        carCoord.x -= MOVE_STEP_X;
-      } else {
-        carCoord.y -= MOVE_STEP_X; // up
-      }
-      blockOverflowPos(carCoord);
-    },
-    [blockOverflowPos]
+  const rankInfoList = useMemo(
+    () =>
+      ingameRoomRes.allMembers
+        .map(({ memberId, nickname, score }) => ({
+          memberId,
+          nickname,
+          currentScore: score,
+          isMe: memberId === userId,
+        }))
+        .sort((prev, next) => next.currentScore - prev.currentScore),
+    [ingameRoomRes.allMembers, userId]
   );
 
-  const timerForTest = setInterval(() => {
-    updateCarCoord(car1Ref.current);
-  }, 1500);
+  const handleUpdateScore = useCallback(
+    (_isAllSubmitted: boolean) => {
+      const newScore = _isAllSubmitted ? 100 : myCurrentScore + scorePerSubmit;
+      publishIngame('/info', { currentScore: newScore });
+    },
+    [myCurrentScore, publishIngame, scorePerSubmit]
+  );
 
-  useEffect(() => {
-    if (car1) {
-      const img = new Image(20, 20); //FIX:사이즈 적용안됨.. car1.png를 불러와서 줄이고싶으면?
-      img.src = car1;
-      img.alt = '자동차';
-      carImageRef.current = img;
-      car1Ref.current = { x: START_X, y: START_Y };
-    }
-
-    let rafTimer: ReturnType<typeof requestAnimationFrame>;
-    const coord = car1Ref.current;
-    const cvs = canvasRef.current;
-    const ctx = cvs?.getContext('2d');
-    if (!ctx) {
+  const handleRoundFinish = useCallback(() => {
+    if (didRoundFinishSubmitted.current) {
       return;
     }
-    const animate = () => {
-      const car = carImageRef.current;
-      if (car) {
-        ctx.drawImage(car, coord.x, coord.y); // 위치!px단위
-      }
-      rafTimer = requestAnimationFrame(animate);
-    };
-    rafTimer = requestAnimationFrame(animate);
-    return () => {
-      rafTimer && cancelAnimationFrame(rafTimer);
-    };
-  }, []);
+
+    publishIngame('/round-finish', { currentRound });
+    didRoundFinishSubmitted.current = true;
+  }, [currentRound, publishIngame]);
+
+  useEffect(() => {
+    if (ingameRoomRes.type === 'NEXT_ROUND_START') {
+      setCurrentRound((prev) => prev + 1);
+      codeList.current = ingameRoomRes.questions!;
+      didRoundFinishSubmitted.current = false;
+      return;
+    }
+  }, [ingameRoomRes.type]);
 
   return (
     <>
-      <IngameHeader />
+      <IngameHeader
+        key={codeList.current[0].question}
+        handleRoundFinish={handleRoundFinish}
+        currentRound={currentRound}
+        timeLimit={
+          convertedCodeList.reduce((prev, cur) => prev + cur.length, 0) *
+          SECONDS_PER_SENTENCE
+        }
+        isNextRound={ingameRoomRes.type === 'NEXT_ROUND_START'}
+      />
       <div>
         <div className='absolute'>
-          <IngameRank />
+          <IngameRank rankInfos={rankInfoList} />
         </div>
         <div className='flex flex-col items-center justify-center ml-80 h-[60rem] relative'>
           <div className='absolute w-full h-full rounded-[14rem] border-2 border-black'></div>
           <div className='absolute w-[calc(100%-5rem)] h-[calc(100%-5rem)] rounded-[14rem] border-2 border-black '></div>
-          <CanvasTrack
-            allMembers={ingameRoomRes.allMembers}
-            isNextRoundStart={ingameRoomRes.type === 'NEXT_ROUND_START'}
-          />
+          <CanvasTrack allMembers={ingameRoomRes.allMembers} />
           <CodeFormContainer
-            dummyCode={dummyCode}
-            convertedDummyCode={convertedDummyCode}
+            key={codeList.current[0].question}
+            codeList={codeList.current}
+            convertedCodeList={convertedCodeList}
             handleUpdateScore={handleUpdateScore}
+            handleRoundFinish={handleRoundFinish}
           />
         </div>
       </div>

--- a/src/pages/GamePage/common/CanvasTrack.tsx
+++ b/src/pages/GamePage/common/CanvasTrack.tsx
@@ -53,7 +53,6 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
 
   const carImgs = [car1, car2, car3, car4, car5, car6, car7, car8];
   let isArrived = 0;
-
   useEffect(() => {
     // 캔버스 세팅
     const cvs = canvasRef.current;
@@ -158,7 +157,7 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
 
   setTimeout(() => {
     isArrived = 1;
-    console.log('임시 종료');
+    // console.log('임시 종료');
   }, 5000);
 
   return (


### PR DESCRIPTION
## 📋 Issue Number
close #134 #109 

## 💻 구현 내용

- 게임 시작시 현재 라운드 및 실제 문제를 연결합니다
- 다음 라운드가 시작되면 새로운 문제를 보여줍니다. 
- 모든 유저가 입력을 다 하거나, 시간이 종료되면 라운드가 종료됩니다. 
- 모든 라운드가 끝나면 인게임 종합 랭킹을 보여줍니다.

## 📷 Screenshots
<img width="1143" alt="스크린샷 2024-03-12 오전 10 35 27" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/17ba2716-4dbe-4164-bb28-073fad4cda6e">
<img width="1146" alt="스크린샷 2024-03-12 오전 10 37 16" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/696b910f-0f08-400f-bda8-959b0270aa08">
<img width="1170" alt="스크린샷 2024-03-12 오전 10 39 03" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/4d0eba0f-bf45-463f-aecf-08214ab318f7">


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
useMemo, useCallback, useEffect, useRef를 완벽하게 이해하지 않고 사용해서 각종 에러가 발생했었습니다....
1. 엔터 키 입력하면 점수가 0점으로 초기화 되서 더해지는 에러 
> handleActiveEnter와 handleUpdateScore의 useCallback의 의존성 배열 다 채워서 해결
2. CodeFormContainer에 useEffect로 라운드가 끝났을 때 round-finish 발행하는 로직을 두니까 라운드가 끝나면 무한 발행하는 에러.. 
> GameCode로 라운드 끝났을 때 round-finish 발행하는 로직(handleRoundFinish)을 두고 props로 전달해서 해결
3. useRef로 convertedCode 만들어서 CodeFormContainer, CodeForm 둘 다 리렌더링이 바로 안되는 에러.. 
> CodeFormContainer, CodeForm에 key 값을 전달해서 해결 

코드가 현재 매우 지저분해서 정리할 필요가 느껴집니다.. 많은 조언 부탁드리겠습니다 🫠
GameSentence의 로직과 매우 유사하여 어느 정도 리팩토링을 통해 정리가 가능할 것 같습니다 👍
<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
