### PR TITLE
[Feat] 랭킹 페이지 연결

### DIFF
--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
+import { useNavigate } from 'react-router-dom';
 import CreateRoomModal from './CreateRoom/CreateRoomModal';
 import EnterRoomErrorFallback from './EnterRoomErrorFallback';
 import GameRoomList from './GameRoomList';
@@ -9,6 +10,8 @@ import UserCard from './UserCard';
 import UserList from './UserList';
 
 const MainPage = () => {
+  const navigate = useNavigate();
+
   return (
     <main className='flex pb-[4rem] gap-[3rem]'>
       <section className='flex flex-col gap-[3rem] w-[25rem]'>
@@ -17,7 +20,9 @@ const MainPage = () => {
             <UserList />
           </Suspense>
         </ErrorBoundary>
-        <article className='flex items-center justify-center bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[4.5rem] w-full'></article>
+        <article className='flex items-center justify-center bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[4.5rem] w-full cursor-pointer hover:bg-green-100 transition-all'>
+          <button onClick={() => navigate('/rank')}>전체 랭킹 페이지</button>
+        </article>
         <UserCard />
       </section>
       <section className='flex-1 grid grid-cols-[3fr_1fr] grid-rows-[5rem_auto] grid-flow-col gap-[3rem]'>

--- a/src/pages/RankPage/RankPage.tsx
+++ b/src/pages/RankPage/RankPage.tsx
@@ -29,7 +29,8 @@ const RankPage = () => {
           <Tabs.Trigger
             key={text}
             value={value}
-            className='bg-green-70 rounded-[1rem] px-8 py-4'>
+            className='bg-green-70 rounded-[1rem] px-8 py-4 data-[state=active]:bg-green-100'
+            data-state={value === selectedTab ? 'active' : 'inactive'}>
             {text}
           </Tabs.Trigger>
         ))}


### PR DESCRIPTION
## 📋 Issue Number
close #165 

## 💻 구현 내용

- 메인화면에서 랭킹 페이지 연결
- 랭킹 페이지에서 활성화된 탭에 색상 추가

## 📷 Screenshots
<img width="252" alt="스크린샷 2024-03-12 오후 2 45 04" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/326aa6ab-8c1e-4c70-a783-0e3319cd4729">
<img width="607" alt="스크린샷 2024-03-12 오후 2 45 19" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/37bfc968-4eea-48fb-9591-c08df01e7f8d">


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
