### PR TITLE
[Feat] useAuthCheck 캐싱 추가, 온라인유저 본인 표시, 유저프로필 데이터 연동

### DIFF
--- a/src/common/AuthRoute/AuthRoute.tsx
+++ b/src/common/AuthRoute/AuthRoute.tsx
@@ -1,5 +1,5 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
-import { useAuthCheck } from '@/hooks/useAuth';
+import { useAuthCheck } from '@/hooks/useAuth/useAuth';
 import storageFactory from '@/utils/storageFactory';
 
 const authMap = new Map([

--- a/src/common/Header/Header.tsx
+++ b/src/common/Header/Header.tsx
@@ -11,7 +11,7 @@ import logo_car from '@/assets/logo_car.png';
 import logo_taza from '@/assets/logo_taza.png';
 import { PAUSE, PLAY } from '@/common/Header/constants/volume';
 import { exchangeVolumeState } from '@/common/Header/utils/exchangeVolumeState';
-import { useAuthCheck } from '@/hooks/useAuth';
+import { useAuthCheck } from '@/hooks/useAuth/useAuth';
 import WrappedIcon from '../WrappedIcon/WrappedIcon';
 
 export type VolumeType = 'play' | 'pause';

--- a/src/generated/api.ts
+++ b/src/generated/api.ts
@@ -52,19 +52,19 @@ export interface AccountGetResponse {
      * @type {number}
      * @memberof AccountGetResponse
      */
-    'rank'?: number;
+    'rank': number;
     /**
      * 
      * @type {number}
      * @memberof AccountGetResponse
      */
-    'gameCount'?: number;
+    'gameCount': number;
     /**
      * 
      * @type {number}
      * @memberof AccountGetResponse
      */
-    'averageCpm'?: number;
+    'averageCpm': number;
     /**
      * 
      * @type {number}

--- a/src/hooks/useAuth/constants.ts
+++ b/src/hooks/useAuth/constants.ts
@@ -1,0 +1,1 @@
+export const MINUTE = 1000 * 60;

--- a/src/hooks/useAuth/useAuth.tsx
+++ b/src/hooks/useAuth/useAuth.tsx
@@ -7,6 +7,7 @@ import {
   ErrorResponse,
 } from '@/generated';
 import storageFactory from '@/utils/storageFactory';
+import { MINUTE } from './constants';
 
 export interface AuthProps {
   onSuccess?: (e: AxiosResponse<ApiResponseAuthResponse>) => void;
@@ -93,7 +94,8 @@ export const useAuthCheck = () => {
     queryFn: getMyProfileInfo,
     queryKey: ['getMyProfileInfo'],
     retryOnMount: false,
-    gcTime: 0,
+    gcTime: MINUTE * 15,
+    staleTime: MINUTE * 10,
     refetchOnWindowFocus: false,
     enabled: !!getItem('MyToken', ''),
     meta: {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import Layout from './common/Layout/Layout.tsx';
 import GamePage from './pages/GamePage/GamePage.tsx';
 import KaKaoLoginPage from './pages/KaKaoLoginPage/KaKaoLoginPage.tsx';
 import LoginPage from './pages/LoginPage/LoginPage.tsx';
+import DefaultErrorFallback from './pages/MainPage/DefaultErrorFallback.tsx';
 import MainPage from './pages/MainPage/MainPage.tsx';
 import NotFoundPage from './pages/NotFoundPage/NotFoundPage.tsx';
 import RankPage from './pages/RankPage/RankPage.tsx';
@@ -58,7 +59,13 @@ export const router = createBrowserRouter([
           },
           {
             path: '/main',
-            element: <MainPage />,
+            element: (
+              <ErrorBoundary fallbackRender={DefaultErrorFallback}>
+                <Suspense>
+                  <MainPage />
+                </Suspense>
+              </ErrorBoundary>
+            ),
           },
           {
             path: '/game',

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import Loading from '@/common/Loading/Loading';
-import { useAuthCheck } from '@/hooks/useAuth';
+import { useAuthCheck } from '@/hooks/useAuth/useAuth';
 import useGameWaitingRoomStore from '@/store/useGameWaitingRoomStore';
 import useRoomInfoStore from '@/store/useRoomInfoStore';
 import WsError from './common/WsError';

--- a/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
+++ b/src/pages/KaKaoLoginPage/KaKaoLoginPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useKaKaoLogin } from '@/hooks/useAuth';
+import { useKaKaoLogin } from '@/hooks/useAuth/useAuth';
 
 const KaKaoLoginPage = () => {
   const navigate = useNavigate();

--- a/src/pages/MainPage/DefaultErrorFallback.tsx
+++ b/src/pages/MainPage/DefaultErrorFallback.tsx
@@ -1,0 +1,14 @@
+import { FallbackProps } from 'react-error-boundary';
+
+const DefaultErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+  return (
+    <div className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 row-start-2 col-start-1 col-span-2'>
+      에러 발생!
+      {error.response.data.errorCode}|{error.response.data.errorMessage}|
+      {error.response.data?.validation?.title}|
+      <button onClick={resetErrorBoundary}>오류초기화</button>
+    </div>
+  );
+};
+
+export default DefaultErrorFallback;

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -33,7 +33,14 @@ const MainPage = () => {
         <article className='flex items-center justify-center bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[4.5rem] w-full cursor-pointer hover:bg-green-100 transition-all'>
           <button onClick={() => navigate('/rank')}>전체 랭킹 페이지</button>
         </article>
-        <UserCard />
+        <UserCard
+          nickname={userData.data.data!.nickname}
+          isGuest={userData.data.data!.isGuest}
+          rank={userData.data.data!.rank}
+          gameCount={userData.data.data!.gameCount}
+          averageCpm={userData.data.data!.averageCpm}
+          averageAccuracy={userData.data.data!.averageAccuracy}
+        />
       </section>
       <section className='flex-1 grid grid-cols-[3fr_1fr] grid-rows-[5rem_auto] grid-flow-col gap-[3rem]'>
         <article className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100'>

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,6 +1,7 @@
-import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
+import { useAuthCheck } from '@/hooks/useAuth/useAuth';
+import useOnlineUsers from '@/hooks/useOnlineUsers';
 import CreateRoomModal from './CreateRoom/CreateRoomModal';
 import EnterRoomErrorFallback from './EnterRoomErrorFallback';
 import GameRoomList from './GameRoomList';
@@ -11,15 +12,24 @@ import UserList from './UserList';
 
 const MainPage = () => {
   const navigate = useNavigate();
+  const { data: userList } = useOnlineUsers();
+  const { data: userData, isPending, error } = useAuthCheck();
+
+  if (isPending) {
+    return <div>유저 정보 불러오는중...</div>;
+  }
+
+  if (error) {
+    return <div>유저 정보 불러오는 중 에러</div>;
+  }
 
   return (
     <main className='flex pb-[4rem] gap-[3rem]'>
       <section className='flex flex-col gap-[3rem] w-[25rem]'>
-        <ErrorBoundary fallback={<div>온라인 접속자 에러</div>}>
-          <Suspense fallback={<span>온라인 접속자 로딩중</span>}>
-            <UserList />
-          </Suspense>
-        </ErrorBoundary>
+        <UserList
+          userList={[...userList.data.data!]}
+          myId={userData.data.data!.memberId}
+        />
         <article className='flex items-center justify-center bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[4.5rem] w-full cursor-pointer hover:bg-green-100 transition-all'>
           <button onClick={() => navigate('/rank')}>전체 랭킹 페이지</button>
         </article>

--- a/src/pages/MainPage/UserCard.tsx
+++ b/src/pages/MainPage/UserCard.tsx
@@ -1,27 +1,37 @@
 import * as Avatar from '@radix-ui/react-avatar';
 
 interface UserCardProps {
+  nickname: string;
   userImage?: string;
   userImageFallbackDelay?: number;
   rank?: number;
+  isGuest: boolean;
+  gameCount: number;
+  averageCpm: number;
+  averageAccuracy: number;
 }
 
 const UserCard = ({
   //테스트용으로 기본값 추가해두었습니다.
+  nickname,
   userImage = 'https://images.unsplash.com/photo-1492633423870-43d1cd2775eb?&w=128&h=128&dpr=2&q=80',
   userImageFallbackDelay = 6000,
-  rank = 0,
+  rank,
+  isGuest,
+  gameCount = 0,
+  averageCpm = 0,
+  averageAccuracy = 0,
 }: UserCardProps) => {
   return (
     <article className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[18rem] w-full p-[1.2rem]'>
       <div className='flex justify-between'>
-        <span className='truncate flex-1'>
-          닉네임이겁나길수도있습니다이렇게
-        </span>
-        <button>(수정)</button>
+        <span className='truncate flex-1'>{nickname}</span>
+        {!isGuest && (
+          <button className='w-[6rem] h-[2.5rem] bg-red-100'>수정</button>
+        )}
       </div>
-      <div className='py-[2.2rem] flex'>
-        <Avatar.Root className='w-1/2'>
+      <div className='pb-[2.2rem] flex'>
+        <Avatar.Root className='w-1/2 pt-[2.2rem]'>
           <Avatar.Image
             className='size-[9rem] rounded-full'
             src={userImage}
@@ -31,8 +41,13 @@ const UserCard = ({
             테스트
           </Avatar.Fallback>
         </Avatar.Root>
-        <div className='flex flex-col-reverse  mx-[1.2rem]'>
-          <span className='bg-coral-50 w-[6.8rem] text-center'>{`${rank ? `${rank}위` : '순위없음'}`}</span>
+
+        {/* Todo: 각 정보 눌렀을때 랭크페이지 이동? */}
+        <div className='flex flex-col-reverse  mx-[1.2rem] gap-[1rem] text-[1.4rem]'>
+          <span className='bg-coral-50 w-[10rem] text-center rounded-[0.5rem] h-[2.2rem] hover:bg-coral-100'>{`${!isGuest ? `${rank}위` : '순위없음'}`}</span>
+          <span className='bg-coral-50 w-[10rem] text-center rounded-[0.5rem] h-[2.2rem] hover:bg-coral-100'>{`플레이 ${gameCount}회`}</span>
+          <span className='bg-coral-50 w-[10rem] text-center rounded-[0.5rem] h-[2.2rem] hover:bg-coral-100'>{`타수 ${averageCpm}타`}</span>
+          <span className='bg-coral-50 w-[10rem] text-center rounded-[0.5rem] h-[2.2rem] hover:bg-coral-100'>{`정확도 ${averageAccuracy}%`}</span>
         </div>
       </div>
     </article>

--- a/src/pages/MainPage/UserCard.tsx
+++ b/src/pages/MainPage/UserCard.tsx
@@ -44,10 +44,10 @@ const UserCard = ({
 
         {/* Todo: 각 정보 눌렀을때 랭크페이지 이동? */}
         <div className='flex flex-col-reverse  mx-[1.2rem] gap-[1rem] text-[1.4rem]'>
-          <span className='bg-coral-50 w-[10rem] text-center rounded-[0.5rem] h-[2.2rem] hover:bg-coral-100'>{`${!isGuest ? `${rank}위` : '순위없음'}`}</span>
+          <span className='bg-coral-50 w-[10rem] text-center rounded-[0.5rem] h-[2.2rem] hover:bg-coral-100'>{`${!isGuest ? `${rank}위` : '순위 없음'}`}</span>
           <span className='bg-coral-50 w-[10rem] text-center rounded-[0.5rem] h-[2.2rem] hover:bg-coral-100'>{`플레이 ${gameCount}회`}</span>
-          <span className='bg-coral-50 w-[10rem] text-center rounded-[0.5rem] h-[2.2rem] hover:bg-coral-100'>{`타수 ${averageCpm}타`}</span>
-          <span className='bg-coral-50 w-[10rem] text-center rounded-[0.5rem] h-[2.2rem] hover:bg-coral-100'>{`정확도 ${averageAccuracy}%`}</span>
+          <span className='bg-coral-50 w-[10rem] text-center rounded-[0.5rem] h-[2.2rem] hover:bg-coral-100'>{`평균 ${averageCpm}타`}</span>
+          <span className='bg-coral-50 w-[10rem] text-center rounded-[0.5rem] h-[2.2rem] hover:bg-coral-100'>{`완벽함 ${averageAccuracy}%`}</span>
         </div>
       </div>
     </article>

--- a/src/pages/MainPage/UserList.tsx
+++ b/src/pages/MainPage/UserList.tsx
@@ -1,8 +1,18 @@
+import { useAuthCheck } from '@/hooks/useAuth/useAuth';
 import useOnlineUsers from '@/hooks/useOnlineUsers';
 import UserListItem from './UserListItem';
 
 const UserList = () => {
   const { data: userList } = useOnlineUsers();
+  const { data: userData, isPending, error } = useAuthCheck();
+
+  if (isPending) {
+    return <div>유저 정보 불러오는중...</div>;
+  }
+
+  if (error) {
+    return <div>유저 정보 불러오는 중 에러</div>;
+  }
 
   return (
     <article className='flex flex-col gap-[1rem] p-[2rem] bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[50rem] w-full'>
@@ -12,7 +22,11 @@ const UserList = () => {
           [...userList.data.data].map(({ nickname, memberId }) => (
             <UserListItem
               key={memberId}
-              username={nickname}
+              username={
+                memberId == userData.data.data?.memberId
+                  ? `${nickname} (본인)`
+                  : `${nickname}`
+              }
             />
           ))
         ) : (

--- a/src/pages/MainPage/UserList.tsx
+++ b/src/pages/MainPage/UserList.tsx
@@ -1,31 +1,22 @@
-import { useAuthCheck } from '@/hooks/useAuth/useAuth';
-import useOnlineUsers from '@/hooks/useOnlineUsers';
 import UserListItem from './UserListItem';
 
-const UserList = () => {
-  const { data: userList } = useOnlineUsers();
-  const { data: userData, isPending, error } = useAuthCheck();
+type UsersType = { nickname: string; memberId: number };
+interface UserListProps {
+  userList?: UsersType[];
+  myId: number;
+}
 
-  if (isPending) {
-    return <div>유저 정보 불러오는중...</div>;
-  }
-
-  if (error) {
-    return <div>유저 정보 불러오는 중 에러</div>;
-  }
-
+const UserList = ({ userList, myId }: UserListProps) => {
   return (
     <article className='flex flex-col gap-[1rem] p-[2rem] bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[50rem] w-full'>
       <h3>현재 접속자</h3>
       <ul className='flex-1 rounded-[0.5rem] bg-green-50 p-[2rem] overflow-y-auto'>
-        {userList.data.data ? (
-          [...userList.data.data].map(({ nickname, memberId }) => (
+        {userList ? (
+          userList.map(({ nickname, memberId }) => (
             <UserListItem
               key={memberId}
               username={
-                memberId == userData.data.data?.memberId
-                  ? `${nickname} (본인)`
-                  : `${nickname}`
+                memberId === myId ? `${nickname} (본인)` : `${nickname}`
               }
             />
           ))

--- a/src/pages/StartPage/StartPage.tsx
+++ b/src/pages/StartPage/StartPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import logo_big_shadow from '@/assets/logo_big_shadow.png';
-import { useGuestLogin } from '@/hooks/useAuth';
+import { useGuestLogin } from '@/hooks/useAuth/useAuth';
 import storageFactory from '@/utils/storageFactory';
 
 const StartPage = () => {


### PR DESCRIPTION
## 📋 Issue Number
close #188

## 💻 구현 내용

- useAuthCheck에 캐싱 10분 넣어두었습니다. 닉네임 변경시 꼭 `invalidateQueries`해주셔야 합니다!!
- 현재 접속중인 유저 목록에서 본인을 확인할 수 있게 표시하였습니다.
- 유저 프로필과 실제 데이터를 연동하였습니다.

## 📷 Screenshots
![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/261748de-b9f2-4bc5-a42a-53ae4fb4d7c3)


## 🤔 고민사항
게스트 유저가 순위표에 마우스 hover하면, '로그인 하셔서 기록을 남겨보세요!' 같은 카드가 프로필을 가리게 하고싶은데 어떻게 생각하시나요? (누르면 로그인 화면으로 이동ㅎㅎ)
