### PR TITLE
[Feat] 전체 라운드 종료 후 게임룸으로 이동

### DIFF
--- a/src/pages/GamePage/GameFinish/GameFinish.tsx
+++ b/src/pages/GamePage/GameFinish/GameFinish.tsx
@@ -13,7 +13,7 @@ const GameFinish = ({ rankData }: { rankData: RankingResponse[] }) => {
 
   const { timeLeft } = useTimer({
     minutes: 0,
-    seconds: 4,
+    seconds: 10,
     onFinishRound: () => {
       onMoveToGameRoom();
     },

--- a/src/pages/GamePage/GameFinish/GameFinish.tsx
+++ b/src/pages/GamePage/GameFinish/GameFinish.tsx
@@ -16,7 +16,7 @@ const GameFinish = ({
   const { setIngameRoomRes } = useIngameStore();
 
   const { timeLeft } = useTimer({
-    minutes: 15,
+    minutes: 0,
     seconds: 10,
     onFinishRound: () => {
       onMoveToGameRoom();

--- a/src/pages/GamePage/GameFinish/GameFinish.tsx
+++ b/src/pages/GamePage/GameFinish/GameFinish.tsx
@@ -1,18 +1,22 @@
 import { useNavigate } from 'react-router-dom';
-import { RankingResponse } from '@/generated';
 import useTimer from '@/hooks/useTimer';
+import { I_ConvertedRankData } from '@/pages/RankPage/types/convertedRankData';
 import useGameWaitingRoomStore from '@/store/useGameWaitingRoomStore';
 import useIngameStore from '@/store/useIngameStore';
 import RankList from '../../RankPage/RankList';
 import { I_IngameWsResponse } from '../types/websocketType';
 
-const GameFinish = ({ rankData }: { rankData: RankingResponse[] }) => {
+const GameFinish = ({
+  convertedRankData,
+}: {
+  convertedRankData: I_ConvertedRankData[];
+}) => {
   const navigate = useNavigate();
   const { setDidAdminStart } = useGameWaitingRoomStore();
   const { setIngameRoomRes } = useIngameStore();
 
   const { timeLeft } = useTimer({
-    minutes: 0,
+    minutes: 15,
     seconds: 10,
     onFinishRound: () => {
       onMoveToGameRoom();
@@ -64,7 +68,7 @@ const GameFinish = ({ rankData }: { rankData: RankingResponse[] }) => {
         </div>
 
         <div className='flex-1'>
-          <RankList rankData={rankData} />
+          <RankList convertedRankData={convertedRankData} />
         </div>
       </section>
       <section className='flex gap-10 font-[Giants-Inline]'>

--- a/src/pages/GamePage/GameFinish/GameFinish.tsx
+++ b/src/pages/GamePage/GameFinish/GameFinish.tsx
@@ -1,20 +1,35 @@
 import { useNavigate } from 'react-router-dom';
 import { RankingResponse } from '@/generated';
 import useTimer from '@/hooks/useTimer';
+import useGameWaitingRoomStore from '@/store/useGameWaitingRoomStore';
+import useIngameStore from '@/store/useIngameStore';
 import RankList from '../../RankPage/RankList';
+import { I_IngameWsResponse } from '../types/websocketType';
 
 const GameFinish = ({ rankData }: { rankData: RankingResponse[] }) => {
   const navigate = useNavigate();
+  const { setDidAdminStart } = useGameWaitingRoomStore();
+  const { setIngameRoomRes } = useIngameStore();
+
   const { timeLeft } = useTimer({
     minutes: 0,
     seconds: 4,
-    onFinishRound: () => navigate('/main', { replace: true }),
+    onFinishRound: () => {
+      onMoveToGameRoom();
+    },
   });
+
+  const onMoveToGameRoom = () => {
+    setDidAdminStart(false);
+    setIngameRoomRes({} as I_IngameWsResponse);
+    navigate('/game', { replace: true });
+  };
+
   return (
     <div className='flex flex-col gap-[8rem] items-center'>
       <section>
         <span className='text-[3rem] font-bold font-[Giants-Inline]'>
-          {`${timeLeft}초 뒤 메인화면으로 이동합니다.`}
+          {`${timeLeft}초 뒤 게임 대기방으로 이동합니다.`}
         </span>
       </section>
       <section className='flex gap-[10rem] w-full'>
@@ -53,10 +68,19 @@ const GameFinish = ({ rankData }: { rankData: RankingResponse[] }) => {
         </div>
       </section>
       <section className='flex gap-10 font-[Giants-Inline]'>
-        <button className='bg-coral-100 px-6 py-6 rounded-[1rem] text-[3rem] font-bold'>
+        <button
+          onClick={() => {
+            navigate('/main', { replace: true });
+            navigate(0);
+          }}
+          className='bg-coral-100 px-6 py-6 rounded-[1rem] text-[3rem] font-bold'>
           로비로 나가기
         </button>
-        <button className='bg-coral-100 px-6 py-6 rounded-[1rem] text-[3rem] font-bold'>
+        <button
+          onClick={() => {
+            onMoveToGameRoom();
+          }}
+          className='bg-coral-100 px-6 py-6 rounded-[1rem] text-[3rem] font-bold'>
           다시하기
         </button>
       </section>

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -14,7 +14,6 @@ const GamePage = () => {
   const navigate = useNavigate();
 
   const { roomId, setRoomInfo, roomInfo } = useRoomInfoStore();
-
   const {
     handlePubReadyGame,
     handlePubStartGame,
@@ -24,15 +23,11 @@ const GamePage = () => {
     handleConnectIngame,
   } = useWebsocket(roomId);
 
-  const { gameRoomRes, isWsError } = useGameWaitingRoomStore();
+  const { gameRoomRes, isWsError, didAdminStart, allMembers } =
+    useGameWaitingRoomStore();
   const isPlaying = useMemo(
     () => gameRoomRes?.roomInfo?.isPlaying,
     [gameRoomRes?.roomInfo]
-  );
-
-  const didAdminStart = useMemo(
-    () => gameRoomRes?.type === 'START',
-    [gameRoomRes?.type]
   );
 
   //Todo => useSuspenseQuery로 변경...
@@ -70,7 +65,7 @@ const GamePage = () => {
     );
   }
 
-  if (isPending || !gameRoomRes || !roomInfo) {
+  if (isPending || !allMembers || !roomInfo) {
     return <Loading />;
   }
 
@@ -81,7 +76,8 @@ const GamePage = () => {
   if (!didAdminStart) {
     return (
       <GameWaitingRoom
-        gameRoomRes={gameRoomRes}
+        allMembers={allMembers}
+        roomInfo={roomInfo}
         handlePubReadyGame={handlePubReadyGame}
         handlePubStartGame={handlePubStartGame}
         handlePubKickUser={handlePubKickUser}

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomInfo.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomInfo.tsx
@@ -1,19 +1,25 @@
 import { GAME_TYPE } from '../constants';
-import { I_GameRoomResponse } from '../types/websocketType';
+import { I_AllMember, I_RoomInfo } from '../types/websocketType';
 
-const GameRoomInfo = ({ gameRoomRes }: { gameRoomRes: I_GameRoomResponse }) => {
+const GameRoomInfo = ({
+  allMembers,
+  roomInfo,
+}: {
+  allMembers: I_AllMember[];
+  roomInfo: I_RoomInfo;
+}) => {
   return (
     <div className='w-[105rem] h-[7.1rem] text-[2rem] flex bg-beige-100 rounded-[2.5rem] shadow-md shadow-black/50 items-center '>
       <div className='flex justify-center items-center w-[25%] h-[70%] border-r border-solid border-black'>
-        No.{gameRoomRes.roomId}
+        No.{roomInfo.id}
       </div>
       <div className='flex justify-center items-center w-[35%] h-[70%] border-r border-solid border-black'>
-        {gameRoomRes.roomInfo?.title}
+        {roomInfo.title}
       </div>
       <div className='flex justify-center items-center w-[20%] h-[70%] border-r border-solid border-black'>
-        {gameRoomRes.roomInfo && GAME_TYPE.get(gameRoomRes.roomInfo?.gameMode)}
+        {roomInfo && GAME_TYPE.get(roomInfo.gameMode)}
       </div>
-      <div className='flex justify-center items-center w-[20%] h-[70%]'>{`${gameRoomRes.allMembers?.length} / ${gameRoomRes.roomInfo?.maxPlayer}`}</div>
+      <div className='flex justify-center items-center w-[20%] h-[70%]'>{`${allMembers.length} / ${roomInfo.maxPlayer}`}</div>
     </div>
   );
 };

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
@@ -14,7 +14,12 @@ const GameRoomUserItem = ({
   userId: number;
   handlePubKickUser: HandlePubKickUserType;
 }) => {
-  const { memberId, nickname, ranking, readyStatus: isReady } = gameRoomUser;
+  const {
+    memberId,
+    nickname,
+    ranking = 0,
+    readyStatus: isReady,
+  } = gameRoomUser;
 
   const isAdmin = useMemo(() => hostId === memberId, [hostId, memberId]); // 방장인지
   const isAdminMe = useMemo(() => hostId === userId, [hostId, userId]); //본인이 방장인지
@@ -49,11 +54,15 @@ const GameRoomUserItem = ({
           <Avatar.Fallback delayMs={6000}>test</Avatar.Fallback>
         </Avatar.Root>
         <div className='w-1/2 flex flex-col justify-evenly text-center'>
-          <div className='w-[10rem] py-[0.4rem] bg-green-70 rounded-[1rem]'>
+          <div className='w-[10rem] h-[3rem] py-[0.4rem] bg-green-70 rounded-[1rem]'>
             {nickname}
           </div>
-          <div className='w-[6.4rem] py-[0.4rem] bg-green-70 rounded-[1rem] text-[1.4rem]'>
-            {ranking === -1 ? '등수 없음' : `${ranking}등`}
+          <div className='w-[10rem] h-[3rem] py-[0.4rem] bg-green-70 rounded-[1rem] text-[1.4rem]'>
+            {ranking === -1
+              ? '등수 없음'
+              : ranking === 0
+                ? '랭킹 반영중'
+                : `${ranking}등`}
           </div>
         </div>
       </div>

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -5,7 +5,8 @@ import {
   HandlePubKickUserType,
   HandlePubReadyGameType,
   HandlePubStartGameType,
-  I_GameRoomResponse,
+  I_AllMember,
+  I_RoomInfo,
 } from '../types/websocketType';
 import GameModeInfo from './GameModeInfo';
 import GameReadyAndStart from './GameReadyAndStart';
@@ -15,19 +16,20 @@ import GameRoomSetting from './GameRoomSetting';
 import GameRoomUserList from './GameRoomUserList';
 
 const GameWaitingRoom = ({
-  gameRoomRes,
+  allMembers,
+  roomInfo,
   handlePubReadyGame,
   handlePubStartGame,
   handlePubKickUser,
   userId,
 }: {
-  gameRoomRes: I_GameRoomResponse;
+  allMembers: I_AllMember[];
+  roomInfo: I_RoomInfo;
   handlePubReadyGame: HandlePubReadyGameType;
   handlePubStartGame: HandlePubStartGameType;
   handlePubKickUser: HandlePubKickUserType;
   userId: number;
 }) => {
-  const { allMembers, roomInfo } = gameRoomRes;
   const [isAlert, setIsAlert] = useState(false);
 
   const isAdmin = userId === roomInfo?.hostId;
@@ -46,7 +48,10 @@ const GameWaitingRoom = ({
       <div className='w-full flex flex-col justify-center items-center gap-[3rem] select-none'>
         <header className='flex gap-[5rem]'>
           <Backward handleClickBackward={handleClickBackward} />
-          <GameRoomInfo gameRoomRes={gameRoomRes} />
+          <GameRoomInfo
+            allMembers={allMembers}
+            roomInfo={roomInfo}
+          />
         </header>
         {allMembers && (
           <GameRoomUserList

--- a/src/pages/GamePage/IngameWebsocketLayer.tsx
+++ b/src/pages/GamePage/IngameWebsocketLayer.tsx
@@ -33,16 +33,17 @@ const IngameWebsocketLayer = ({
     return <WsError />;
   }
 
-  const rankData = ingameRoomRes.allMembers
-    .map(({ nickname, score }) => ({
+  const convertedRankData = ingameRoomRes.allMembers
+    .map(({ nickname, score, memberId }) => ({
       nickname,
       score,
+      isMe: memberId === userId,
     }))
     .sort(({ score: prevScore }, { score: nextScore }) => nextScore - prevScore)
     .map((el, i) => ({ ...el, ranking: i + 1 }));
 
   if (ingameRoomRes.type === 'FINISH') {
-    return <GameFinish rankData={rankData} />;
+    return <GameFinish convertedRankData={convertedRankData} />;
   }
 
   return (

--- a/src/pages/GamePage/common/CanvasTrack.tsx
+++ b/src/pages/GamePage/common/CanvasTrack.tsx
@@ -158,8 +158,6 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
 
   setTimeout(() => {
     isArrived = 1;
-
-    // console.log('임시 종료');
   }, 5000);
 
   return (

--- a/src/pages/GamePage/hooks/useWebsocket.ts
+++ b/src/pages/GamePage/hooks/useWebsocket.ts
@@ -14,7 +14,13 @@ const useWebsocket = (roomId: number | null) => {
 
   const connectHeaders = getToken();
 
-  const { setGameRoomRes, isWsError, setIsWsError } = useGameWaitingRoomStore();
+  const {
+    setGameRoomRes,
+    isWsError,
+    setIsWsError,
+    setDidAdminStart,
+    setAllMembers,
+  } = useGameWaitingRoomStore();
   const { setIsIngameWsError, setIngameRoomRes } = useIngameStore();
 
   useEffect(() => {
@@ -71,6 +77,17 @@ const useWebsocket = (roomId: number | null) => {
       if (checkIsEmptyObj(responsePublish)) {
         setIsWsError(true);
       }
+
+      if (responsePublish.type === 'START') {
+        setDidAdminStart(true);
+      }
+      if (
+        responsePublish.type === 'EXIT' ||
+        responsePublish.type === 'ENTER' ||
+        responsePublish.type === 'READY'
+      ) {
+        setAllMembers(responsePublish.allMembers);
+      }
     };
 
     const handleEnterGameRoom = (roomId: number) => {
@@ -123,6 +140,9 @@ const useWebsocket = (roomId: number | null) => {
     setIngameRoomRes(responsePublish);
     if (checkIsEmptyObj(responsePublish)) {
       setIsIngameWsError(true);
+    }
+    if (responsePublish.type === 'FINISH') {
+      setAllMembers(responsePublish.allMembers);
     }
   };
   const publishIngame = (destination: string, payload: PayloadType) => {

--- a/src/pages/RankPage/RankItem.tsx
+++ b/src/pages/RankPage/RankItem.tsx
@@ -1,10 +1,10 @@
 import first from '@/assets/rank/first_rank.png';
 import second from '@/assets/rank/second_rank.png';
 import third from '@/assets/rank/third_rank.png';
-import { RankingResponse } from '@/generated';
+import { I_ConvertedRankData } from './types/convertedRankData';
 
 interface RankItemProps {
-  rank: RankingResponse;
+  rank: I_ConvertedRankData;
   index: number;
 }
 
@@ -27,7 +27,10 @@ const RankItem = ({ rank, index }: RankItemProps) => {
           rank.ranking
         )}
       </span>
-      <span className='flex-1 text-center'>{rank.nickname}</span>
+      <span className='flex-1 text-center'>
+        {rank.nickname}
+        <strong>{rank.isMe && `(나)`}</strong>
+      </span>
       <span className='flex-1 text-center'>{rank.score}</span>
     </div>
   );

--- a/src/pages/RankPage/RankList.tsx
+++ b/src/pages/RankPage/RankList.tsx
@@ -1,18 +1,18 @@
 import { useMemo } from 'react';
-import { RankingResponse } from '@/generated';
 import RankItem from './RankItem';
+import { I_ConvertedRankData } from './types/convertedRankData';
 
 export interface RankListProps {
-  rankData: RankingResponse[] | undefined;
+  convertedRankData: I_ConvertedRankData[] | undefined;
 }
 
-const RankList = ({ rankData }: RankListProps) => {
-  const sortedRankData = useMemo(() => {
-    if (!rankData) {
+const RankList = ({ convertedRankData }: RankListProps) => {
+  const sortedConvertedRankData = useMemo(() => {
+    if (!convertedRankData) {
       return [];
     }
-    return [...rankData].sort((a, b) => a.ranking - b.ranking);
-  }, [rankData]);
+    return [...convertedRankData].sort((a, b) => a.ranking - b.ranking);
+  }, [convertedRankData]);
 
   return (
     <div className='flex flex-col rounded-2xl overflow-hidden'>
@@ -21,7 +21,7 @@ const RankList = ({ rankData }: RankListProps) => {
         <span className='flex-1 text-center'>닉네임</span>
         <span className='flex-1 text-center'>점수</span>
       </div>
-      {sortedRankData.map((rank, index) => (
+      {sortedConvertedRankData.map((rank, index) => (
         <RankItem
           key={rank.ranking}
           rank={rank}

--- a/src/pages/RankPage/RankPage.tsx
+++ b/src/pages/RankPage/RankPage.tsx
@@ -39,7 +39,7 @@ const RankPage = () => {
         <Tabs.Content
           key={text}
           value={value}>
-          <RankList rankData={rankData.data.data} />
+          <RankList convertedRankData={rankData.data.data} />
         </Tabs.Content>
       ))}
     </Tabs.Root>

--- a/src/pages/RankPage/types/convertedRankData.ts
+++ b/src/pages/RankPage/types/convertedRankData.ts
@@ -1,0 +1,5 @@
+import { RankingResponse } from '@/generated';
+
+export interface I_ConvertedRankData extends RankingResponse {
+  isMe?: boolean;
+}

--- a/src/store/useGameWaitingRoomStore.ts
+++ b/src/store/useGameWaitingRoomStore.ts
@@ -1,11 +1,20 @@
 import { create } from 'zustand';
-import { I_GameRoomResponse } from '@/pages/GamePage/types/websocketType';
+import {
+  I_AllMember,
+  I_GameRoomResponse,
+} from '@/pages/GamePage/types/websocketType';
 
 interface I_UseGameWaitingRoom {
   gameRoomRes: I_GameRoomResponse | null;
   setGameRoomRes: (gameRoomRes: I_GameRoomResponse) => void;
   isWsError: boolean;
   setIsWsError: (isWsError: boolean) => void;
+
+  didAdminStart: boolean;
+  setDidAdminStart: (didAdminStart: boolean) => void;
+
+  allMembers: I_AllMember[] | undefined;
+  setAllMembers: (allMembers: I_AllMember[]) => void;
 }
 
 const useGameWaitingRoomStore = create<I_UseGameWaitingRoom>((set) => ({
@@ -13,6 +22,12 @@ const useGameWaitingRoomStore = create<I_UseGameWaitingRoom>((set) => ({
   setGameRoomRes: (gameRoomRes) => set({ gameRoomRes }),
   isWsError: false,
   setIsWsError: (isWsError) => set({ isWsError }),
+
+  didAdminStart: false,
+  setDidAdminStart: (didAdminStart) => set({ didAdminStart }),
+
+  allMembers: undefined,
+  setAllMembers: (allMembers) => set({ allMembers }),
 }));
 
 export default useGameWaitingRoomStore;


### PR DESCRIPTION
## 📋 Issue Number
close #171 #199 

## 💻 구현 내용

- 전체라운드 종료 -> 랭킹화면 -> 10초후에 게임룸으로 이동합니다.
- 10초후 이외에도 '메인 화면(로비)으로 나가기', '게임룸으로 나가기' 연결
- 라운드 종료 후 다시 게임 대기방으로 갈 수 있도록 하는 로직
    - **GameFinish.tsx**
- 로직에 필요한 상태 등을 store에 최신화
    - **useWebsocket.ts**
- 로직에 필요한 상태를 store에 추가
    - **useGameWaitingRoomStore.ts**
- 추가한 상태에 따라 달라진 props 전달
    - GamePage.tsx
    - GameRoomInfo.tsx
    - GameRoomUserItem.tsx
    - GameWaitingRoom.tsx
- 게임 종료 후 랭킹에서 본인 순위 확인 기능 추가
## 📷 Screenshots
https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/671ef687-8842-4bde-8abe-b7875e1c151a

<img width="793" alt="스크린샷 2024-03-13 오후 10 37 22" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/a1b21a86-f261-440b-860d-785c0028a8cc">


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
최대한 해봤는데 놓친 부분이 있을 수도 있고, 기능이 동작하도록 구현해서 부족한 부분이 있을 수 있습니다 ㅠㅠ 
놓친 부분이 있다면 바로 말씀해주세요!

## TroubleShooting
* store에 있는 ingameRoomRes 의 type이 FINISH 임 → 준비 취소하고 다시 준비하고 게임 시작하면 GameFinish 컴포넌트가 매우 짧은 시간 렌더링 됨  → setIngameRoomRes ({} as I_ingameRoomRes) 로 해결
* store에 있는 allMembers의 readyStatus가 모두 true 임 → 시작 버튼이 활성화 되어 있는 버그 -> ingameRoomRes의 type이 finish일 때 allMembers의 readyStatus가 초기화 되는 것을 이용해서 해결
<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
