### PR TITLE
[Fix] 랭킹 점수 내림처리, IngameHeader내부 timer 리턴값 문자열로 사용

### DIFF
--- a/src/common/Ingame/IngameHeader.tsx
+++ b/src/common/Ingame/IngameHeader.tsx
@@ -3,6 +3,7 @@ import useTimer from '@/hooks/useTimer';
 import DisconnectModal from '@/pages/GamePage/common/DisconnectModal';
 import useRoomInfoStore from '@/store/useRoomInfoStore';
 import Backward from '../Backward/Backward';
+import { convertTime } from '../Timer/utils/convertTime';
 
 interface IngameHeaderProps {
   handleRoundFinish: () => void;
@@ -51,7 +52,7 @@ const IngameHeader = ({
         <div className='grow'>참여 {roomInfo?.currentPlayer}명</div>
         <div>
           <span className='font-bold font-[Giants-Inline] text-[3.2rem]'>
-            남은 시간 : {timeLeft}
+            남은 시간 : {convertTime(timeLeft)}
           </span>
         </div>
         <div className='text-[3rem]'>

--- a/src/pages/RankPage/RankItem.tsx
+++ b/src/pages/RankPage/RankItem.tsx
@@ -31,7 +31,7 @@ const RankItem = ({ rank, index }: RankItemProps) => {
         {rank.nickname}
         <strong>{rank.isMe && `(나)`}</strong>
       </span>
-      <span className='flex-1 text-center'>{rank.score}</span>
+      <span className='flex-1 text-center'>{Math.floor(rank.score)}</span>
     </div>
   );
 };


### PR DESCRIPTION
## 📋 Issue Number
close #204 

## 💻 구현 내용

- 랭킹 점수 내림처리, IngameHeader내부 timer 리턴값 문자열로 사용
- 큰 변경은 없습니다!

