### PR TITLE
[Feat] 각 라운드별 대기시간 추가

### DIFF
--- a/src/common/Ingame/IngameHeader.tsx
+++ b/src/common/Ingame/IngameHeader.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import useTimer from '@/hooks/useTimer';
 import DisconnectModal from '@/pages/GamePage/common/DisconnectModal';
+import useIngameStore from '@/store/useIngameStore';
 import useRoomInfoStore from '@/store/useRoomInfoStore';
 import Backward from '../Backward/Backward';
 import { convertTime } from '../Timer/utils/convertTime';
@@ -21,18 +22,28 @@ const IngameHeader = ({
   isNextRound,
 }: IngameHeaderProps) => {
   const { roomInfo } = useRoomInfoStore();
+  const { isRoundWaiting } = useIngameStore();
+
   const [isAlert, setIsAlert] = useState(false);
-  const { timeLeft, resetTimer } = useTimer({
+
+  const { timeLeft, resetTimer, startTimer } = useTimer({
     minutes: Math.floor(timeLimit / SECONDS_PER_MINUTE),
-    seconds: timeLimit % SECONDS_PER_MINUTE,
+    seconds: 10,
     onTimeFinish: () => {
       handleRoundFinish();
     },
+    autoStart: false,
   });
 
   useEffect(() => {
     isNextRound && resetTimer();
+    return () => resetTimer();
   }, [isNextRound]);
+
+  useEffect(() => {
+    !isRoundWaiting && startTimer();
+    return () => resetTimer();
+  }, [isRoundWaiting]);
 
   const handleClickBackward = () => {
     setIsAlert(true);

--- a/src/common/Ingame/IngameHeader.tsx
+++ b/src/common/Ingame/IngameHeader.tsx
@@ -25,7 +25,7 @@ const IngameHeader = ({
   const { timeLeft, resetTimer } = useTimer({
     minutes: Math.floor(timeLimit / SECONDS_PER_MINUTE),
     seconds: timeLimit % SECONDS_PER_MINUTE,
-    onFinishRound: () => {
+    onTimeFinish: () => {
       handleRoundFinish();
     },
   });

--- a/src/common/Ingame/IngameHeader.tsx
+++ b/src/common/Ingame/IngameHeader.tsx
@@ -28,7 +28,7 @@ const IngameHeader = ({
 
   const { timeLeft, resetTimer, startTimer } = useTimer({
     minutes: Math.floor(timeLimit / SECONDS_PER_MINUTE),
-    seconds: 10,
+    seconds: timeLimit % SECONDS_PER_MINUTE,
     onTimeFinish: () => {
       handleRoundFinish();
     },

--- a/src/common/Timer/Timer.tsx
+++ b/src/common/Timer/Timer.tsx
@@ -4,7 +4,7 @@ const Timer = () => {
   const { timeLeft } = useTimer({
     minutes: 0,
     seconds: 10,
-    onFinishRound: () => {
+    onTimeFinish: () => {
       alert('시간이 종료되었습니다.');
     },
   });

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -4,13 +4,13 @@ export const SECOND = 1000;
 export const MIN_SECOND = 60 * SECOND;
 
 interface TimerProps {
-  minutes: number;
+  minutes?: number;
   seconds: number;
-  onFinishRound: () => void;
+  onTimeFinish?: () => void;
 }
 
 // 커스텀 훅 useTimer 정의
-const useTimer = ({ minutes = 0, seconds = 0, onFinishRound }: TimerProps) => {
+const useTimer = ({ minutes = 0, seconds = 0, onTimeFinish }: TimerProps) => {
   const [timeLeft, setTimeLeft] = useState<number>(
     minutes * MIN_SECOND + seconds * SECOND
   );
@@ -19,7 +19,7 @@ const useTimer = ({ minutes = 0, seconds = 0, onFinishRound }: TimerProps) => {
   useEffect(() => {
     if (timeLeft <= 0) {
       clearInterval(timerRef.current!);
-      onFinishRound();
+      onTimeFinish?.();
       // 여기서는 시간이 0이 되었을 때의 로직만 처리합니다.
     }
   }, [timeLeft]);

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export const SECOND = 1000;
 export const MIN_SECOND = 60 * SECOND;
@@ -7,14 +7,26 @@ interface TimerProps {
   minutes?: number;
   seconds: number;
   onTimeFinish?: () => void;
+  autoStart?: boolean;
 }
 
 // 커스텀 훅 useTimer 정의
-const useTimer = ({ minutes = 0, seconds = 0, onTimeFinish }: TimerProps) => {
+const useTimer = ({
+  minutes = 0,
+  seconds = 0,
+  onTimeFinish,
+  autoStart = true,
+}: TimerProps) => {
   const [timeLeft, setTimeLeft] = useState<number>(
     minutes * MIN_SECOND + seconds * SECOND
   );
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startTimer = useCallback(() => {
+    timerRef.current = setInterval(() => {
+      setTimeLeft((prevTime) => prevTime - SECOND);
+    }, SECOND);
+  }, []);
 
   useEffect(() => {
     if (timeLeft <= 0) {
@@ -25,10 +37,7 @@ const useTimer = ({ minutes = 0, seconds = 0, onTimeFinish }: TimerProps) => {
   }, [timeLeft]);
 
   useEffect(() => {
-    timerRef.current = setInterval(() => {
-      setTimeLeft((prevTime) => prevTime - SECOND);
-    }, SECOND);
-
+    autoStart && startTimer();
     return () => {
       if (timerRef.current !== null) {
         clearInterval(timerRef.current);
@@ -43,12 +52,10 @@ const useTimer = ({ minutes = 0, seconds = 0, onTimeFinish }: TimerProps) => {
       clearInterval(timerRef.current);
     }
     // 타이머 다시 시작
-    timerRef.current = setInterval(() => {
-      setTimeLeft((prevTime) => prevTime - SECOND);
-    }, SECOND);
+    autoStart && startTimer();
   };
 
-  return { timeLeft, resetTimer };
+  return { timeLeft, resetTimer, startTimer };
 };
 
 export default useTimer;

--- a/src/pages/GamePage/GameFinish/GameFinish.tsx
+++ b/src/pages/GamePage/GameFinish/GameFinish.tsx
@@ -18,7 +18,7 @@ const GameFinish = ({
   const { timeLeft } = useTimer({
     minutes: 0,
     seconds: 10,
-    onFinishRound: () => {
+    onTimeFinish: () => {
       onMoveToGameRoom();
     },
   });

--- a/src/pages/GamePage/GameFinish/GameFinish.tsx
+++ b/src/pages/GamePage/GameFinish/GameFinish.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import { convertTime } from '@/common/Timer/utils/convertTime';
 import useTimer from '@/hooks/useTimer';
 import { I_ConvertedRankData } from '@/pages/RankPage/types/convertedRankData';
 import useGameWaitingRoomStore from '@/store/useGameWaitingRoomStore';
@@ -33,7 +34,7 @@ const GameFinish = ({
     <div className='flex flex-col gap-[8rem] items-center'>
       <section>
         <span className='text-[3rem] font-bold font-[Giants-Inline]'>
-          {`${timeLeft}초 뒤 게임 대기방으로 이동합니다.`}
+          {`${convertTime(timeLeft)}초 뒤 게임 대기방으로 이동합니다.`}
         </span>
       </section>
       <section className='flex gap-[10rem] w-full'>

--- a/src/pages/GamePage/GameSentence/GameFormContainer.tsx
+++ b/src/pages/GamePage/GameSentence/GameFormContainer.tsx
@@ -25,7 +25,7 @@ const GameFormContainer = ({
 
   return (
     <>
-      <div className='flex flex-col items-center justify-center z-10'>
+      <div className='flex flex-col items-center justify-center'>
         <GameForm
           key={sentenceList[sentenceIdx]?.question ?? ''}
           sample={sentenceList[sentenceIdx]?.question ?? ''}

--- a/src/pages/GamePage/IngameWebsocketLayer.tsx
+++ b/src/pages/GamePage/IngameWebsocketLayer.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import useIngameStore from '@/store/useIngameStore';
 import useRoomInfoStore from '@/store/useRoomInfoStore';
 import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
+import RoundWaitModal from './common/RoundWaitModal';
 import WsError from './common/WsError';
 import GameCode from './GameCode/GameCode';
 import GameFinish from './GameFinish/GameFinish';
@@ -22,12 +23,22 @@ const IngameWebsocketLayer = ({
   handleConnectIngame,
 }: IngameWebsocketLayerProps) => {
   const { roomId, roomInfo } = useRoomInfoStore();
-  const { ingameRoomRes, isIngameWsError } = useIngameStore();
+  const { ingameRoomRes, isIngameWsError, isRoundWaiting, setIsRoundWaiting } =
+    useIngameStore();
 
   useEffect(() => {
     onIngameConnected(); // 인게임 엔드포인트 구독
     handleConnectIngame(roomId); // 해당 인게임 연결 발행
   }, []);
+
+  useEffect(() => {
+    if (
+      ingameRoomRes.type === 'FIRST_ROUND_START' ||
+      ingameRoomRes.type === 'NEXT_ROUND_START'
+    ) {
+      setIsRoundWaiting(true);
+    }
+  }, [ingameRoomRes.type]);
 
   if (isIngameWsError || checkIsEmptyObj(ingameRoomRes)) {
     return <WsError />;
@@ -46,8 +57,18 @@ const IngameWebsocketLayer = ({
     return <GameFinish convertedRankData={convertedRankData} />;
   }
 
+  /* 
+  1. 'FIRST_ROUND_START', 'NEXT_ROUND_START'일때 waiting이라는 상태가 true가 됨.
+  2. waiting이 true일 시 타이머와 함께 modal 등장.
+  3. 타이머가 종료되면, waiting을 false로 만든다.
+  */
+
   return (
     <>
+      <RoundWaitModal
+        isOpen={isRoundWaiting}
+        onTimeFinish={() => setIsRoundWaiting(false)}
+      />
       {roomInfo?.gameMode === 'SENTENCE' && (
         <GameSentence
           publishIngame={publishIngame}

--- a/src/pages/GamePage/IngameWebsocketLayer.tsx
+++ b/src/pages/GamePage/IngameWebsocketLayer.tsx
@@ -57,12 +57,6 @@ const IngameWebsocketLayer = ({
     return <GameFinish convertedRankData={convertedRankData} />;
   }
 
-  /* 
-  1. 'FIRST_ROUND_START', 'NEXT_ROUND_START'일때 waiting이라는 상태가 true가 됨.
-  2. waiting이 true일 시 타이머와 함께 modal 등장.
-  3. 타이머가 종료되면, waiting을 false로 만든다.
-  */
-
   return (
     <>
       <RoundWaitModal

--- a/src/pages/GamePage/common/RoundWaitModal.tsx
+++ b/src/pages/GamePage/common/RoundWaitModal.tsx
@@ -1,18 +1,29 @@
 import * as Dialog from '@radix-ui/react-dialog';
+import { convertTime } from '@/common/Timer/utils/convertTime';
+import useTimer from '@/hooks/useTimer';
 
 interface RoundWaitModalProps {
   isOpen: boolean;
-  timeLeft: number;
+  onTimeFinish: () => void;
 }
 
-const RoundWaitModal = ({ isOpen, timeLeft }: RoundWaitModalProps) => {
+const RoundWaitModal = ({ isOpen, onTimeFinish }: RoundWaitModalProps) => {
+  const { timeLeft, resetTimer } = useTimer({
+    seconds: 5,
+    onTimeFinish: () => {
+      onTimeFinish();
+      resetTimer();
+    },
+  });
+
   return (
     <Dialog.Root open={isOpen}>
       <Dialog.Portal>
-        <Dialog.Overlay className='z-100 fixed inset-0 w-[100vw] h-[100vh] bg-black/70 animate-[overlayShow_150ms_cubic-bezier(0.16,1,0.3,1)]' />
-        <Dialog.Content className='`rounded-[1rem] border-green-100 border-[0.3rem] w-[30rem] h-[15rem] flex flex-col items-center justify-center bg-white z-10 fixed inset-1/2 translate-x-[-50%] translate-y-[-50%]'>
-          {timeLeft}
-          ㅎㅇ
+        <Dialog.Overlay className='z-100 fixed inset-0 w-[100vw] h-[100vh] bg-black/30 animate-[overlayShow_150ms_cubic-bezier(0.16,1,0.3,1)]' />
+        <Dialog.Content className='`w-[30rem] h-[15rem] flex flex-col items-center justify-center z-10 fixed inset-1/2 translate-x-[-50%] translate-y-[-50%]'>
+          <span className='text-[10rem]'>
+            {timeLeft === 0 ? 'start' : convertTime(timeLeft).split(':')[1]}!
+          </span>
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>

--- a/src/pages/GamePage/common/RoundWaitModal.tsx
+++ b/src/pages/GamePage/common/RoundWaitModal.tsx
@@ -1,0 +1,22 @@
+import * as Dialog from '@radix-ui/react-dialog';
+
+interface RoundWaitModalProps {
+  isOpen: boolean;
+  timeLeft: number;
+}
+
+const RoundWaitModal = ({ isOpen, timeLeft }: RoundWaitModalProps) => {
+  return (
+    <Dialog.Root open={isOpen}>
+      <Dialog.Portal>
+        <Dialog.Overlay className='z-100 fixed inset-0 w-[100vw] h-[100vh] bg-black/70 animate-[overlayShow_150ms_cubic-bezier(0.16,1,0.3,1)]' />
+        <Dialog.Content className='`rounded-[1rem] border-green-100 border-[0.3rem] w-[30rem] h-[15rem] flex flex-col items-center justify-center bg-white z-10 fixed inset-1/2 translate-x-[-50%] translate-y-[-50%]'>
+          {timeLeft}
+          ㅎㅇ
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};
+
+export default RoundWaitModal;

--- a/src/store/useIngameStore.ts
+++ b/src/store/useIngameStore.ts
@@ -4,15 +4,23 @@ import { I_IngameWsResponse } from '@/pages/GamePage/types/websocketType';
 interface I_useIngameStore {
   ingameRoomRes: I_IngameWsResponse;
   setIngameRoomRes: (ingameRoomRes: I_IngameWsResponse) => void;
+
   isIngameWsError: boolean;
   setIsIngameWsError: (isIngameWsError: boolean) => void;
+
+  isRoundWaiting: boolean;
+  setIsRoundWaiting: (isRoundWaiting: boolean) => void;
 }
 
 const useIngameStore = create<I_useIngameStore>((set) => ({
   ingameRoomRes: {} as I_IngameWsResponse,
   setIngameRoomRes: (ingameRoomRes) => set({ ingameRoomRes }),
+
   isIngameWsError: false,
   setIsIngameWsError: (isIngameWsError) => set({ isIngameWsError }),
+
+  isRoundWaiting: false,
+  setIsRoundWaiting: (isRoundWaiting) => set({ isRoundWaiting }),
 }));
 
 export default useIngameStore;

--- a/src/store/useIngameStore.ts
+++ b/src/store/useIngameStore.ts
@@ -19,7 +19,7 @@ const useIngameStore = create<I_useIngameStore>((set) => ({
   isIngameWsError: false,
   setIsIngameWsError: (isIngameWsError) => set({ isIngameWsError }),
 
-  isRoundWaiting: false,
+  isRoundWaiting: true,
   setIsRoundWaiting: (isRoundWaiting) => set({ isRoundWaiting }),
 }));
 


### PR DESCRIPTION
## 📋 Issue Number
close #176 

## 💻 구현 내용

- 라운드 시작 전 카운트다운을 추가하였습니다.
- 이를 위하여 useTimer 로직을 변경하였습니다. (startTimer함수와 autoStart옵션 추가)
- 라운드 종료시 대기방이동 남은시간 ms표기에서 seconds로 변경하였습니다(영상에는 반영 안됨)

## 📷 Screenshots

https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/2a6d15ef-3dd5-4a5f-a9db-574e3066b9a5


## 🤔 고민사항
- 급하게 만들어서 그런지 컴포넌트가 재사용성이 떨어지네요 ㅎㅎ 
- 대기시간은 얼마가 적절할까요?
- UI는 임시라서 조언 팍팍 부탁드립니다
