### PR TITLE
[Fix] 인게임랭킹 유저-자동차 연결

### DIFF
--- a/src/common/Ingame/IngameRank.tsx
+++ b/src/common/Ingame/IngameRank.tsx
@@ -1,7 +1,10 @@
 import { TRACK_CARS } from '@/assets/canvasCars';
 import { I_RankInfoList } from '@/pages/GamePage/GameSentence/GameSentence';
+import useCarImgStore from '@/store/useCarStore';
 
 const IngameRank = ({ rankInfos }: { rankInfos: I_RankInfoList[] }) => {
+  const { carImgStore } = useCarImgStore();
+
   return (
     <>
       {rankInfos.map((rankInfo, i) => {
@@ -14,7 +17,7 @@ const IngameRank = ({ rankInfos }: { rankInfos: I_RankInfoList[] }) => {
             </div>
             <div className='text-[2rem]'>
               <img
-                src={TRACK_CARS[i]}
+                src={TRACK_CARS[carImgStore[rankInfo.memberId]]}
                 width={rankInfo.isMe ? '25px' : '20px'}
               />
             </div>

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import Backward from '@/common/Backward/Backward';
+import useCarImgStore from '@/store/useCarStore';
 import DisconnectModal from '../common/DisconnectModal';
 import {
   HandlePubKickUserType,
@@ -33,6 +34,7 @@ const GameWaitingRoom = ({
   const [isAlert, setIsAlert] = useState(false);
 
   const isAdmin = userId === roomInfo?.hostId;
+  const { setCarImgStore } = useCarImgStore();
 
   const handleClickBackward = () => {
     setIsAlert(true);
@@ -43,7 +45,7 @@ const GameWaitingRoom = ({
       const { memberId } = car;
       carIdxArray[memberId] = idx;
     });
-    // setCarImgStore(carIdxArray);
+    setCarImgStore(carIdxArray);
   }, [allMembers]);
   return (
     <>

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Backward from '@/common/Backward/Backward';
 import DisconnectModal from '../common/DisconnectModal';
 import {
@@ -37,6 +37,14 @@ const GameWaitingRoom = ({
   const handleClickBackward = () => {
     setIsAlert(true);
   };
+  useEffect(() => {
+    const carIdxArray: { [key: string]: number } = {};
+    allMembers.forEach((car, idx) => {
+      const { memberId } = car;
+      carIdxArray[memberId] = idx;
+    });
+    // setCarImgStore(carIdxArray);
+  }, [allMembers]);
   return (
     <>
       <DisconnectModal

--- a/src/store/useCarStore.ts
+++ b/src/store/useCarStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface I_useCarImgStore {
+  carImgStore: Record<number, string>;
+  setCarImgStore: (carImgStore: Record<number, string>) => void;
+}
+
+const useCarImgStore = create<I_useCarImgStore>((set) => ({
+  carImgStore: {},
+  setCarImgStore: (carImgStore) => set({ carImgStore }),
+}));
+
+export default useCarImgStore;

--- a/src/store/useCarStore.ts
+++ b/src/store/useCarStore.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand';
 
 interface I_useCarImgStore {
-  carImgStore: Record<number, string>;
-  setCarImgStore: (carImgStore: Record<number, string>) => void;
+  carImgStore: Record<number, number>;
+  setCarImgStore: (carImgStore: Record<number, number>) => void;
 }
 
 const useCarImgStore = create<I_useCarImgStore>((set) => ({


### PR DESCRIPTION
## 📋 Issue Number
close #211 

## 💻 구현 내용

- 유저 각각에 자동차 이미지 지정
- 인게임 랭킹에 반영

## 📷 Screenshots

https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/81412212/a542ffcc-308a-42a8-9cdb-66ef4b7d7201



## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
게임룸에서 참여자 정보가 계속 바뀌다가 게임시작하는 시점의 최종 참여자를 가지고, { 유저번호 : 이미지인덱스} 의 배열 store를 저장하게 했습니다.
게임룸에서 저장 -> ingameRank에서 사용까지 props가 길어지는 것 같아서 store로 이용했는데 다른 방법이 있을까요 
<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
