### PR TITLE
[Feat] 게임방에서 본인에 대한 식별 추가

### DIFF
--- a/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
@@ -28,7 +28,8 @@ const GameRoomUserItem = ({
   const isMe = useMemo(() => memberId === userId, [memberId, userId]); // 각 유저가 본인인지 -> 방장이자 본인일떄 강퇴식별용
 
   return (
-    <div className='w-[25.8rem] h-[21.2rem] p-[1.6rem] pb-[4rem] relative flex flex-col bg-white shadow-md shadow-black/50 rounded-[2.5rem]'>
+    <div
+      className={`w-[25.8rem] h-[21.2rem] p-[1.6rem] pb-[4rem] relative flex flex-col shadow-md shadow-black/50 rounded-[2.5rem] ${isMe ? 'bg-beige-100' : 'bg-white'}`}>
       <div className='h-[3rem] self-end'>
         <button
           onClick={() => {
@@ -49,10 +50,11 @@ const GameRoomUserItem = ({
           className='w-[10rem]'
           alt='자동차'
         />
-
         <div className='w-1/2 flex flex-col justify-evenly text-center'>
-          <div className='w-[10rem] h-[3rem] py-[0.4rem] bg-green-70 rounded-[1rem]'>
+          <div
+            className={`w-[10rem] ${isMe ? 'h-[5rem]' : 'h-[3rem]'} py-[0.4rem] bg-green-70 rounded-[1rem]`}>
             {nickname}
+            {isMe && ' (본인)'}
           </div>
           <div className='w-[10rem] h-[3rem] py-[0.4rem] bg-green-70 rounded-[1rem] text-[1.4rem]'>
             {ranking === -1

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -39,6 +39,7 @@ const GameWaitingRoom = ({
   const handleClickBackward = () => {
     setIsAlert(true);
   };
+
   useEffect(() => {
     const carIdxArray: { [key: string]: number } = {};
     allMembers.forEach((car, idx) => {
@@ -47,6 +48,7 @@ const GameWaitingRoom = ({
     });
     setCarImgStore(carIdxArray);
   }, [allMembers]);
+
   return (
     <>
       <DisconnectModal

--- a/src/pages/GamePage/common/DisconnectModal.tsx
+++ b/src/pages/GamePage/common/DisconnectModal.tsx
@@ -15,8 +15,8 @@ const DisconnectModal = ({
     <AlertDialog.Root open={isOpen}>
       <AlertDialog.Trigger asChild></AlertDialog.Trigger>
       <AlertDialog.Portal>
-        <AlertDialog.Overlay className='fixed inset-0 w-[100vw] h-[100vh] bg-black/30 animate-[overlayShow_150ms_cubic-bezier(0.16,1,0.3,1)]' />
-        <AlertDialog.Content className='data-[state=open]:animate-contentShow fixed top-[50%] left-[50%] max-h-[85vh] w-[90vw] max-w-[500px] translate-x-[-50%] translate-y-[-50%] rounded-[6px] bg-white p-[25px] shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none z-10'>
+        <AlertDialog.Overlay className='fixed inset-0 w-[100vw] h-[100vh] bg-black/30 animate-[overlayShow_150ms_cubic-bezier(0.16,1,0.3,1)] z-[100]' />
+        <AlertDialog.Content className='data-[state=open]:animate-contentShow fixed top-[50%] left-[50%] max-h-[85vh] w-[90vw] max-w-[500px] translate-x-[-50%] translate-y-[-50%] rounded-[6px] bg-white p-[25px] shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none z-[100]'>
           <AlertDialog.Title className='text-mauve12 m-0 text-[17px] font-medium'>
             정말로 게임방을 나가시겠어요?
           </AlertDialog.Title>


### PR DESCRIPTION
## 📋 Issue Number
close #222 

## 💻 구현 내용

- 게임방에서 본인에 대한 식별 기능 추가
- 나가기 클릭시 등장하는 모달 콘텐츠 z-index 변경 및 오버레이 z-index 추가

## 📷 Screenshots
<img width="877" alt="스크린샷 2024-03-15 오전 10 10 18" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/bac6d153-3bf4-48fe-af3e-97adca73ec19">
<img width="739" alt="스크린샷 2024-03-15 오전 10 10 50" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/3f4418b7-ac06-4f88-b624-9faed05da534">


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
본인일 때 좀 더 구분을 잘할 수 있도록 하려면 어떻게 해야할까요? 🤔

색상을 임시로 추가해봤는데 좋은 아이디어 추천해주시면 감사하겠습니다!!
<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
