### PR TITLE
[Feat] mutation시 디바운스 기능 추가

### DIFF
--- a/src/hooks/useCreateGameRoom.ts
+++ b/src/hooks/useCreateGameRoom.ts
@@ -1,17 +1,17 @@
-import { useMutation } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
 import { createGameRoom } from '@/apis/api';
 import {
   ApiResponseGameRoomCreateResponse,
   GameRoomCreateRequest,
 } from '@/generated';
+import { useDebouncedMutation } from './useDebouncedMutation';
 
 export interface UseCreateGameRoomProps {
   onSuccess?: (e: AxiosResponse<ApiResponseGameRoomCreateResponse>) => void;
 }
 
 const useCreateGameRoom = ({ onSuccess }: UseCreateGameRoomProps) => {
-  return useMutation<
+  return useDebouncedMutation<
     AxiosResponse<ApiResponseGameRoomCreateResponse>,
     Error | AxiosError,
     GameRoomCreateRequest,

--- a/src/hooks/useDebouncedMutation.ts
+++ b/src/hooks/useDebouncedMutation.ts
@@ -1,0 +1,61 @@
+import {
+  DefaultError,
+  useMutation,
+  UseMutationOptions,
+  UseMutationResult,
+} from '@tanstack/react-query';
+import { useRef } from 'react';
+
+type DebouncedMutateType<
+  TData = unknown,
+  TError = DefaultError,
+  TVariables = void,
+  TContext = unknown,
+> = (
+  variables: TVariables,
+  debounceMs?: number,
+  options?: UseMutationOptions<TData, TError, TVariables, TContext>
+) => void;
+
+type UseDebouncedMutationReturnType<
+  TData = unknown,
+  TError = DefaultError,
+  TVariables = void,
+  TContext = unknown,
+> = Omit<
+  UseMutationResult<TData, TError, TVariables, TContext>,
+  'data' | 'mutate'
+> & {
+  debouncedMutate: DebouncedMutateType<TData, TError, TVariables, TContext>;
+};
+
+export function useDebouncedMutation<
+  TData = unknown,
+  TError = DefaultError,
+  TVariables = void,
+  TContext = unknown,
+>(
+  options: UseMutationOptions<TData, TError, TVariables, TContext>
+): UseDebouncedMutationReturnType<TData, TError, TVariables, TContext> {
+  const { mutate, ...mutation } = useMutation<
+    TData,
+    TError,
+    TVariables,
+    TContext
+  >(options);
+
+  const timer = useRef<ReturnType<typeof setTimeout>>();
+
+  const debouncedMutate: DebouncedMutateType<
+    TData,
+    TError,
+    TVariables,
+    TContext
+  > = (variables, debounceMs = 200, options) => {
+    clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      mutate(variables, options);
+    }, debounceMs);
+  };
+  return { debouncedMutate, ...mutation };
+}

--- a/src/pages/MainPage/CreateRoom/CreateRoomForm.tsx
+++ b/src/pages/MainPage/CreateRoom/CreateRoomForm.tsx
@@ -69,17 +69,18 @@ const CreateRoomForm = ({
     },
   });
 
-  const { debouncedMutate: mutateCreateGameRoom } = useCreateGameRoom({
-    onSuccess: (e) => {
-      if (!e.data.data) {
-        return;
-      }
-      alert('방 생성 성공');
-      setRoomId(e.data.data.roomId);
-      setIsOpen(false);
-      navigate('/game');
-    },
-  });
+  const { debouncedMutate: mutateCreateGameRoom, isPending } =
+    useCreateGameRoom({
+      onSuccess: (e) => {
+        if (!e.data.data) {
+          return;
+        }
+        alert('방 생성 성공');
+        setRoomId(e.data.data.roomId);
+        setIsOpen(false);
+        navigate('/game');
+      },
+    });
 
   const { mutate: mutateUpdateGameRoom } = useUpdateGameRoom({
     onSuccess: () => {
@@ -209,7 +210,7 @@ const CreateRoomForm = ({
           <button
             type='submit'
             className='w-[8rem] p-[0.5rem] rounded-[0.8rem] absolute bottom-[2rem] right-[2rem] bg-coral-100 disabled:cursor-not-allowed disabled:opacity-50 transition-all'
-            disabled={!isValid}>
+            disabled={!isValid || isPending}>
             {settingMode === 'Create' ? '방 생성' : '수정'}
           </button>
         </Form.Submit>

--- a/src/pages/MainPage/CreateRoom/CreateRoomForm.tsx
+++ b/src/pages/MainPage/CreateRoom/CreateRoomForm.tsx
@@ -69,7 +69,7 @@ const CreateRoomForm = ({
     },
   });
 
-  const { mutate: mutateCreateGameRoom } = useCreateGameRoom({
+  const { debouncedMutate: mutateCreateGameRoom } = useCreateGameRoom({
     onSuccess: (e) => {
       if (!e.data.data) {
         return;


### PR DESCRIPTION
## 📋 Issue Number
close #99 

## 💻 구현 내용

- useMutation을 래핑한 useDebounceMutation을 제작하였습니다.
- 디바운스 딜레이는 기본 0.2초 입니다!
- 방 생성 mutation후 응답 오기전까지 방 생성버튼을 disabled처리 하였습니다.

## 📷 Screenshots


## 🤔 고민사항

- 응답이 더 길면 답답할 것 같아서 0.2초로 하였는데 최적의 시간은 몇초일까용?
- 다른 mutation에는 버그 찾으면서 천천히 적용해보겠습니다..!!
