### PR TITLE
[Fix] 게임 목록 '전체' 탭에서 게임중인 방 목록 안보이게 수정

### DIFF
--- a/src/pages/MainPage/GameRoomList.tsx
+++ b/src/pages/MainPage/GameRoomList.tsx
@@ -15,13 +15,11 @@ interface GameRoomListProps {
 const GameRoomList = ({ data, selectedGameMode }: GameRoomListProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
+  const waitingRoomList = data.filter(({ isPlaying }) => !isPlaying);
   const filteredRoomList =
     selectedGameMode !== 'ALL'
-      ? data.filter(
-          ({ isPlaying, gameMode }) =>
-            !isPlaying && gameMode === selectedGameMode
-        )
-      : data;
+      ? waitingRoomList.filter(({ gameMode }) => gameMode === selectedGameMode)
+      : waitingRoomList;
 
   return (
     <article className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 row-start-2 col-start-1 col-span-2'>


### PR DESCRIPTION
## 📋 Issue Number
close #229 

## 💻 구현 내용

- 게임 방 목록 필터링 '전체' 에서 게임중인 방 목록 보이던 부분 수정하였습니다.

## 📷 Screenshots

### 게임중 아닐때

![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/833168ff-1aff-4149-9739-115470dcb81c)

### 게임중 일때

![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/2ca4534d-d0ec-4e81-8fae-f0bbdeec342a)


## 🤔 고민사항

실수가 잦아져서 죄송합니다...😭