### PR TITLE
[Fix] 문장게임 오타 검출 로직 수정

### DIFF
--- a/src/pages/GamePage/GameSentence/GameForm.tsx
+++ b/src/pages/GamePage/GameSentence/GameForm.tsx
@@ -121,7 +121,8 @@ const GameForm = ({
     const currentIndex = inputText.length - 1;
 
     //현재 글자 + 바로 이전글자의 오타 boolean
-    let isLeastCharTypo = false;
+    let isCurrentCharTypo = false;
+    let isPrevCharTypo = false;
 
     //현재 글자 오타검출
     const isTypoAtTypingChar = getTypo(
@@ -129,7 +130,7 @@ const GameForm = ({
       inputText[currentIndex]
     );
 
-    isLeastCharTypo = isTypoAtTypingChar;
+    isCurrentCharTypo = isTypoAtTypingChar;
 
     handleTypoMark(isTypoAtTypingChar, currentIndex);
 
@@ -141,7 +142,7 @@ const GameForm = ({
         true
       );
 
-      isLeastCharTypo = isTypoPrevChar;
+      isPrevCharTypo = isTypoPrevChar;
 
       handleTypoMark(isTypoPrevChar, currentIndex - 1);
     }
@@ -159,7 +160,12 @@ const GameForm = ({
     }
 
     //현재+바로이전글자 오타 or 지금까지 최소한번의 오타 or 이전글자가 공백이 아니면 return
-    if (isLeastCharTypo || isTypoAtLeastOnce || inputText.at(-1) !== ' ') {
+    if (
+      isPrevCharTypo ||
+      isCurrentCharTypo ||
+      isTypoAtLeastOnce ||
+      inputText.at(-1) !== ' '
+    ) {
       return;
     }
 


### PR DESCRIPTION
## 📋 Issue Number
close #232 

## 💻 구현 내용

- 문장게임 띄어쓰기시 예시 문장에 글자가 있어서 틀렸지만, 점수가 올라가는 버그를 수정하였습니다.

## 📷 Screenshots

![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/c4afd531-769e-41e1-b538-70d66bf2c687)


**수정 전에는 점수가 올라 차량이 움직였습니다!**

## 🤔 고민사항
SSOT를 지키지 않아서 로직에 헛점이 많네요..ㅠㅠ