### PR TITLE
[Fix] 이탈 유저 인게임 트랙에서 반영

### DIFF
--- a/src/generated/api.ts
+++ b/src/generated/api.ts
@@ -206,6 +206,31 @@ export interface ApiResponseGameRoomInviteCodeResponse {
 /**
  * 
  * @export
+ * @interface ApiResponseGuestResponse
+ */
+export interface ApiResponseGuestResponse {
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiResponseGuestResponse
+     */
+    'code': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiResponseGuestResponse
+     */
+    'message': string;
+    /**
+     * 
+     * @type {GuestResponse}
+     * @memberof ApiResponseGuestResponse
+     */
+    'data'?: GuestResponse;
+}
+/**
+ * 
+ * @export
  * @interface ApiResponseListRankingResponse
  */
 export interface ApiResponseListRankingResponse {
@@ -472,6 +497,19 @@ export interface GameRoomUpdateRequest {
      * @memberof GameRoomUpdateRequest
      */
     'gameType': string;
+}
+/**
+ * 
+ * @export
+ * @interface GuestResponse
+ */
+export interface GuestResponse {
+    /**
+     * 
+     * @type {string}
+     * @memberof GuestResponse
+     */
+    'accessToken': string;
 }
 /**
  * 
@@ -1038,6 +1076,40 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
+         * @summary 게스트 로그아웃
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        logout1: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/auth/logout/guest`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary 토큰 재발급
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1301,7 +1373,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async guestLogin(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponseAuthResponse>> {
+        async guestLogin(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponseGuestResponse>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.guestLogin(options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.guestLogin']?.[localVarOperationServerIndex]?.url;
@@ -1343,6 +1415,18 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             const localVarAxiosArgs = await localVarAxiosParamCreator.logout(options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.logout']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @summary 게스트 로그아웃
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async logout1(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponseVoid>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.logout1(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.logout1']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
@@ -1483,7 +1567,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        guestLogin(options?: any): AxiosPromise<ApiResponseAuthResponse> {
+        guestLogin(options?: any): AxiosPromise<ApiResponseGuestResponse> {
             return localVarFp.guestLogin(options).then((request) => request(axios, basePath));
         },
         /**
@@ -1514,6 +1598,15 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          */
         logout(options?: any): AxiosPromise<ApiResponseVoid> {
             return localVarFp.logout(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary 게스트 로그아웃
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        logout1(options?: any): AxiosPromise<ApiResponseVoid> {
+            return localVarFp.logout1(options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -1693,6 +1786,17 @@ export class DefaultApi extends BaseAPI {
      */
     public logout(options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).logout(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary 게스트 로그아웃
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public logout1(options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).logout1(options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import Backward from '@/common/Backward/Backward';
 import useCarImgStore from '@/store/useCarStore';
 import DisconnectModal from '../common/DisconnectModal';
+import { CarImgType } from '../types/ingameTypes';
 import {
   HandlePubKickUserType,
   HandlePubReadyGameType,
@@ -45,7 +46,7 @@ const GameWaitingRoom = ({
   }, []);
 
   useEffect(() => {
-    const carIdxArray: { [key: string]: number } = {};
+    const carIdxArray: CarImgType = {};
     allMembers.forEach((car, idx) => {
       const { memberId } = car;
       carIdxArray[memberId] = idx;

--- a/src/pages/GamePage/common/CanvasTrack.tsx
+++ b/src/pages/GamePage/common/CanvasTrack.tsx
@@ -42,7 +42,6 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
   const carImagesRef = useRef<HTMLImageElement[] | null>(null);
   const carsRef = useRef<I_CarCoord[]>([]);
   carsRef.current = [];
-  let isArrived = 0;
 
   useEffect(() => {
     // 캔버스 세팅
@@ -133,22 +132,14 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
           }
         });
       }
-
-      // 도착전까지만 animate를 실행한다. (임시)
-      if (!isArrived) {
-        rafTimer = requestAnimationFrame(animate);
-      }
+      rafTimer = requestAnimationFrame(animate);
     };
 
-    rafTimer = requestAnimationFrame(animate); //////////////실행
+    rafTimer = requestAnimationFrame(animate);
     return () => {
       rafTimer && cancelAnimationFrame(rafTimer);
     };
   }, [allMembers]);
-
-  setTimeout(() => {
-    isArrived = 1;
-  }, 5000);
 
   return (
     <canvas

--- a/src/pages/GamePage/common/CanvasTrack.tsx
+++ b/src/pages/GamePage/common/CanvasTrack.tsx
@@ -18,6 +18,7 @@ import {
   WEST_START_Y,
 } from '@/common/Ingame/ingameConstants';
 import useCanvas from '@/hooks/useCanvas';
+import useCarImgStore from '@/store/useCarStore';
 import { I_AllMember } from '../types/websocketType';
 
 interface I_CarCoord {
@@ -35,6 +36,7 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
       canvas.height = CANVAS_HEIGHT;
     },
   });
+  const { carImgStore } = useCarImgStore();
 
   const prevData = useRef<I_AllMember[]>(allMembers);
   const carImagesRef = useRef<HTMLImageElement[] | null>(null);
@@ -51,14 +53,14 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
     }
 
     // 자동차 이미지 로드
-    if (TRACK_CARS.length) {
-      const carImagesArr = [];
-      for (const carImg of TRACK_CARS) {
+    if (allMembers.length) {
+      const carImagesArr: HTMLImageElement[] | null = [];
+      allMembers.forEach(({ memberId }) => {
         const newImg = new Image(20, 20);
-        newImg.src = carImg;
+        newImg.src = TRACK_CARS[carImgStore[memberId]];
         newImg.alt = '자동차';
         carImagesArr.push(newImg);
-      }
+      });
       carImagesRef.current = carImagesArr;
     }
     console.log(prevData.current, allMembers);

--- a/src/pages/GamePage/common/CanvasTrack.tsx
+++ b/src/pages/GamePage/common/CanvasTrack.tsx
@@ -39,7 +39,7 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
   const prevData = useRef<I_AllMember[]>(allMembers);
   const carImagesRef = useRef<HTMLImageElement[] | null>(null);
   const carsRef = useRef<I_CarCoord[]>([]);
-
+  carsRef.current = [];
   let isArrived = 0;
 
   useEffect(() => {
@@ -61,9 +61,10 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
       }
       carImagesRef.current = carImagesArr;
     }
-
+    console.log(prevData.current, allMembers);
     // allMembers 유저수 만큼 좌표 지정
     allMembers.forEach((member, idx) => {
+      console.log('<<', member);
       const { score } = member;
       const lineGap = (idx % 4) * 10;
 
@@ -113,6 +114,7 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
         y = lineGap;
       }
       carsRef.current[idx] = { x, y, idx };
+      console.log(carsRef);
       prevData.current[idx].score = member.score;
     });
 

--- a/src/pages/GamePage/common/CanvasTrack.tsx
+++ b/src/pages/GamePage/common/CanvasTrack.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/common/Ingame/ingameConstants';
 import useCanvas from '@/hooks/useCanvas';
 import useCarImgStore from '@/store/useCarStore';
+import { CarImgType } from '../types/ingameTypes';
 import { I_AllMember } from '../types/websocketType';
 
 interface I_CarCoord {
@@ -38,7 +39,7 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
   });
   const { carImgStore } = useCarImgStore();
 
-  const prevData = useRef<{ [key: string]: number }>({});
+  const prevData = useRef<CarImgType>({});
   const carImagesRef = useRef<HTMLImageElement[] | null>(null);
   const carsRef = useRef<I_CarCoord[]>([]);
   carsRef.current = [];

--- a/src/pages/GamePage/common/CanvasTrack.tsx
+++ b/src/pages/GamePage/common/CanvasTrack.tsx
@@ -38,7 +38,7 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
   });
   const { carImgStore } = useCarImgStore();
 
-  const prevData = useRef<I_AllMember[]>(allMembers);
+  const prevData = useRef<{ [key: string]: number }>({});
   const carImagesRef = useRef<HTMLImageElement[] | null>(null);
   const carsRef = useRef<I_CarCoord[]>([]);
   carsRef.current = [];
@@ -63,18 +63,17 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
       });
       carImagesRef.current = carImagesArr;
     }
-    console.log(prevData.current, allMembers);
+
     // allMembers 유저수 만큼 좌표 지정
     allMembers.forEach((member, idx) => {
-      console.log('<<', member);
       const { score } = member;
       const lineGap = (idx % 4) * 10;
 
       let x = 0;
       let y = 0;
 
-      // 변화 없는 유저 얼리리턴
-      if (prevData.current[idx].score === member.score) {
+      // // 변화 없는 유저 얼리리턴
+      if (prevData.current[idx] === member.score) {
         if (score === 0) {
           x = START_X + Math.floor(idx / 4) * 20;
           y = lineGap;
@@ -116,8 +115,7 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
         y = lineGap;
       }
       carsRef.current[idx] = { x, y, idx };
-      console.log(carsRef);
-      prevData.current[idx].score = member.score;
+      prevData.current[member.memberId] = member.score;
     });
 
     //자동차를 화면에 그린다

--- a/src/pages/GamePage/hooks/useWebsocket.ts
+++ b/src/pages/GamePage/hooks/useWebsocket.ts
@@ -73,14 +73,16 @@ const useWebsocket = (roomId: number | null) => {
       if (
         responsePublish.type === 'ENTER' ||
         responsePublish.type === 'READY' ||
-        responsePublish.type === 'MODIFIED'
+        responsePublish.type === 'MODIFIED' ||
+        responsePublish.type === 'EXIT'
       ) {
         setAllMembers(responsePublish.allMembers);
       }
-      if (responsePublish.type === 'EXIT') {
+      if (
+        responsePublish.type === 'EXIT' &&
         responsePublish.roomInfo.isPlaying
-          ? setIngameRoomRes(responsePublish.exitMemberId)
-          : setAllMembers(responsePublish.allMembers);
+      ) {
+        setIngameRoomRes(responsePublish.exitMemberId);
       }
     };
 

--- a/src/pages/GamePage/hooks/useWebsocket.ts
+++ b/src/pages/GamePage/hooks/useWebsocket.ts
@@ -21,8 +21,7 @@ const useWebsocket = (roomId: number | null) => {
     setDidAdminStart,
     setAllMembers,
   } = useGameWaitingRoomStore();
-  const { setIsIngameWsError, setIngameRoomRes, setIngameRoomRes2 } =
-    useIngameStore();
+  const { setIsIngameWsError, setIngameRoomRes } = useIngameStore();
 
   useEffect(() => {
     if (!roomId) {
@@ -65,7 +64,7 @@ const useWebsocket = (roomId: number | null) => {
       const responsePublish = JSON.parse(body);
       if (responsePublish.type === 'EXIT') {
         if (responsePublish.roomInfo.isPlaying) {
-          setIngameRoomRes2(responsePublish.exitMemberId);
+          setIngameRoomRes(responsePublish.exitMemberId);
         } else {
           setAllMembers(responsePublish.allMembers);
         }

--- a/src/pages/GamePage/hooks/useWebsocket.ts
+++ b/src/pages/GamePage/hooks/useWebsocket.ts
@@ -21,7 +21,8 @@ const useWebsocket = (roomId: number | null) => {
     setDidAdminStart,
     setAllMembers,
   } = useGameWaitingRoomStore();
-  const { setIsIngameWsError, setIngameRoomRes } = useIngameStore();
+  const { setIsIngameWsError, setIngameRoomRes, setIngameRoomRes2 } =
+    useIngameStore();
 
   useEffect(() => {
     if (!roomId) {
@@ -62,6 +63,13 @@ const useWebsocket = (roomId: number | null) => {
 
     const onMessageReceived = ({ body }: { body: string }) => {
       const responsePublish = JSON.parse(body);
+      if (responsePublish.type === 'EXIT') {
+        if (responsePublish.roomInfo.isPlaying) {
+          setIngameRoomRes2(responsePublish.exitMemberId);
+        } else {
+          setAllMembers(responsePublish.allMembers);
+        }
+      }
       setGameRoomRes(responsePublish);
       if (checkIsEmptyObj(responsePublish)) {
         setIsWsError(true);
@@ -71,7 +79,6 @@ const useWebsocket = (roomId: number | null) => {
         setDidAdminStart(true);
       }
       if (
-        responsePublish.type === 'EXIT' ||
         responsePublish.type === 'ENTER' ||
         responsePublish.type === 'READY' ||
         responsePublish.type === 'MODIFIED'

--- a/src/pages/GamePage/hooks/useWebsocket.ts
+++ b/src/pages/GamePage/hooks/useWebsocket.ts
@@ -82,7 +82,7 @@ const useWebsocket = (roomId: number | null) => {
         responsePublish.type === 'EXIT' &&
         responsePublish.roomInfo.isPlaying
       ) {
-        setIngameRoomRes(responsePublish.exitMemberId);
+        setIngameRoomRes(responsePublish);
       }
     };
 

--- a/src/pages/GamePage/hooks/useWebsocket.ts
+++ b/src/pages/GamePage/hooks/useWebsocket.ts
@@ -62,13 +62,6 @@ const useWebsocket = (roomId: number | null) => {
 
     const onMessageReceived = ({ body }: { body: string }) => {
       const responsePublish = JSON.parse(body);
-      if (responsePublish.type === 'EXIT') {
-        if (responsePublish.roomInfo.isPlaying) {
-          setIngameRoomRes(responsePublish.exitMemberId);
-        } else {
-          setAllMembers(responsePublish.allMembers);
-        }
-      }
       setGameRoomRes(responsePublish);
       if (checkIsEmptyObj(responsePublish)) {
         setIsWsError(true);
@@ -83,6 +76,11 @@ const useWebsocket = (roomId: number | null) => {
         responsePublish.type === 'MODIFIED'
       ) {
         setAllMembers(responsePublish.allMembers);
+      }
+      if (responsePublish.type === 'EXIT') {
+        responsePublish.roomInfo.isPlaying
+          ? setIngameRoomRes(responsePublish.exitMemberId)
+          : setAllMembers(responsePublish.allMembers);
       }
     };
 

--- a/src/pages/GamePage/types/ingameTypes.ts
+++ b/src/pages/GamePage/types/ingameTypes.ts
@@ -1,0 +1,1 @@
+export type CarImgType = { [key: number]: number };

--- a/src/pages/GamePage/types/trackType.ts
+++ b/src/pages/GamePage/types/trackType.ts
@@ -1,1 +1,0 @@
-export type DirectionType = 'right' | 'down' | 'left' | 'up';

--- a/src/pages/GamePage/types/websocketType.ts
+++ b/src/pages/GamePage/types/websocketType.ts
@@ -58,10 +58,6 @@ export type IngameMessageType =
   | 'WORD_DENIED'
   | 'FINISH';
 
-export type GameScoreType = {
-  [key: string]: number;
-};
-
 export type PayloadType =
   | { currentScore: number }
   | { word: string }

--- a/src/store/useCarStore.ts
+++ b/src/store/useCarStore.ts
@@ -1,8 +1,9 @@
 import { create } from 'zustand';
+import { CarImgType } from '@/pages/GamePage/types/ingameTypes';
 
 interface I_useCarImgStore {
-  carImgStore: Record<number, number>;
-  setCarImgStore: (carImgStore: Record<number, number>) => void;
+  carImgStore: CarImgType;
+  setCarImgStore: (carImgStore: CarImgType) => void;
 }
 
 const useCarImgStore = create<I_useCarImgStore>((set) => ({

--- a/src/store/useIngameStore.ts
+++ b/src/store/useIngameStore.ts
@@ -1,10 +1,11 @@
 import { create } from 'zustand';
 import { I_IngameWsResponse } from '@/pages/GamePage/types/websocketType';
 
+type SetByNewOneType = (ingameRoomRes: I_IngameWsResponse) => void;
+type SetByExitType = (exitmemberId: number) => void;
 interface I_useIngameStore {
   ingameRoomRes: I_IngameWsResponse;
-  setIngameRoomRes: (ingameRoomRes: I_IngameWsResponse) => void;
-  setIngameRoomRes2: (exitmemberId: number) => void;
+  setIngameRoomRes: SetByNewOneType | SetByExitType;
 
   isIngameWsError: boolean;
   setIsIngameWsError: (isIngameWsError: boolean) => void;
@@ -15,18 +16,19 @@ interface I_useIngameStore {
 
 const useIngameStore = create<I_useIngameStore>((set) => ({
   ingameRoomRes: {} as I_IngameWsResponse,
-  setIngameRoomRes: (ingameRoomRes) => {
-    set({ ingameRoomRes });
-  },
-  setIngameRoomRes2: (exitmemberId) => {
-    set((prev) => ({
-      ingameRoomRes: {
-        type: prev.ingameRoomRes.type,
-        allMembers: prev.ingameRoomRes.allMembers.filter(
-          ({ memberId }) => memberId !== exitmemberId
-        ),
-      },
-    }));
+  setIngameRoomRes: (props: number | I_IngameWsResponse) => {
+    if (typeof props === 'number') {
+      set((prev) => ({
+        ingameRoomRes: {
+          type: prev.ingameRoomRes.type,
+          allMembers: prev.ingameRoomRes.allMembers.filter(
+            ({ memberId }) => memberId !== props
+          ),
+        },
+      }));
+    } else {
+      set({ ingameRoomRes: props });
+    }
   },
 
   isIngameWsError: false,

--- a/src/store/useIngameStore.ts
+++ b/src/store/useIngameStore.ts
@@ -1,7 +1,10 @@
 import { create } from 'zustand';
-import { I_IngameWsResponse } from '@/pages/GamePage/types/websocketType';
+import {
+  I_GameRoomResponse,
+  I_IngameWsResponse,
+} from '@/pages/GamePage/types/websocketType';
 
-type IngameRoomResSetterType = number | I_IngameWsResponse;
+type IngameRoomResSetterType = I_GameRoomResponse | I_IngameWsResponse;
 interface I_useIngameStore {
   ingameRoomRes: I_IngameWsResponse;
   setIngameRoomRes: <T extends IngameRoomResSetterType>(props: T) => void;
@@ -15,13 +18,15 @@ interface I_useIngameStore {
 
 const useIngameStore = create<I_useIngameStore>((set) => ({
   ingameRoomRes: {} as I_IngameWsResponse,
-  setIngameRoomRes: <T extends IngameRoomResSetterType>(props: T) => {
-    if (typeof props === 'number') {
+  setIngameRoomRes: (props: I_GameRoomResponse | I_IngameWsResponse) => {
+    if ('roomId' in props) {
       set((prev) => ({
         ingameRoomRes: {
-          type: prev.ingameRoomRes.type,
-          allMembers: prev.ingameRoomRes.allMembers.filter(
-            ({ memberId }) => memberId !== props
+          ...prev.ingameRoomRes,
+          allMembers: prev.ingameRoomRes.allMembers.filter(({ memberId }) =>
+            props.allMembers?.some(
+              ({ memberId: newMemberId }) => newMemberId === memberId
+            )
           ),
         },
       }));

--- a/src/store/useIngameStore.ts
+++ b/src/store/useIngameStore.ts
@@ -4,6 +4,7 @@ import { I_IngameWsResponse } from '@/pages/GamePage/types/websocketType';
 interface I_useIngameStore {
   ingameRoomRes: I_IngameWsResponse;
   setIngameRoomRes: (ingameRoomRes: I_IngameWsResponse) => void;
+  setIngameRoomRes2: (exitmemberId: number) => void;
 
   isIngameWsError: boolean;
   setIsIngameWsError: (isIngameWsError: boolean) => void;
@@ -14,7 +15,19 @@ interface I_useIngameStore {
 
 const useIngameStore = create<I_useIngameStore>((set) => ({
   ingameRoomRes: {} as I_IngameWsResponse,
-  setIngameRoomRes: (ingameRoomRes) => set({ ingameRoomRes }),
+  setIngameRoomRes: (ingameRoomRes) => {
+    set({ ingameRoomRes });
+  },
+  setIngameRoomRes2: (exitmemberId) => {
+    set((prev) => ({
+      ingameRoomRes: {
+        type: prev.ingameRoomRes.type,
+        allMembers: prev.ingameRoomRes.allMembers.filter(
+          ({ memberId }) => memberId !== exitmemberId
+        ),
+      },
+    }));
+  },
 
   isIngameWsError: false,
   setIsIngameWsError: (isIngameWsError) => set({ isIngameWsError }),

--- a/src/store/useIngameStore.ts
+++ b/src/store/useIngameStore.ts
@@ -1,11 +1,10 @@
 import { create } from 'zustand';
 import { I_IngameWsResponse } from '@/pages/GamePage/types/websocketType';
 
-type SetByNewOneType = (ingameRoomRes: I_IngameWsResponse) => void;
-type SetByExitType = (exitmemberId: number) => void;
+type IngameRoomResSetterType = number | I_IngameWsResponse;
 interface I_useIngameStore {
   ingameRoomRes: I_IngameWsResponse;
-  setIngameRoomRes: SetByNewOneType | SetByExitType;
+  setIngameRoomRes: <T extends IngameRoomResSetterType>(props: T) => void;
 
   isIngameWsError: boolean;
   setIsIngameWsError: (isIngameWsError: boolean) => void;
@@ -16,7 +15,7 @@ interface I_useIngameStore {
 
 const useIngameStore = create<I_useIngameStore>((set) => ({
   ingameRoomRes: {} as I_IngameWsResponse,
-  setIngameRoomRes: (props: number | I_IngameWsResponse) => {
+  setIngameRoomRes: <T extends IngameRoomResSetterType>(props: T) => {
     if (typeof props === 'number') {
       set((prev) => ({
         ingameRoomRes: {


### PR DESCRIPTION
## 📋 Issue Number
close #225 

## 💻 구현 내용

- 인게임 중 유저 이탈시 해당 유저의 자동차 바로 제거
  -> 게임룸에 EXIT 응답시 ingameRoomRes를 업데이트 합니다 -> zustand setter 함수 타입을 변경했습니다.
- 게임룸에서부터 배정받은 memberId-자동차 이미지 쌍 (carImgStore)을 인게임 트랙에서도 유지합니다 

## 📷 Screenshots

https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/81412212/fd34d1ab-bd85-4879-889d-ce4ba511525a




## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
추가 예외사항 발견하시면 알려주세요..
시작위치 위에서부터 
1
2
순으로 게임을 시작했다가 1번유저가  2번유저가 윗층(y좌표상 위쪽)으로 이동됩니다.. 추가 PR에서 수정하겠습니다.
<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
