### PR TITLE
[Fix] 인게임 이탈시 roomInfo 초기화

### DIFF
--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
 import { useAuthCheck } from '@/hooks/useAuth/useAuth';
 import useOnlineUsers from '@/hooks/useOnlineUsers';
+import useRoomInfoStore from '@/store/useRoomInfoStore';
 import { GameModeType } from '@/types/gameMode';
 import CreateRoomModal from './CreateRoom/CreateRoomModal';
 import EnterRoomErrorFallback from './EnterRoomErrorFallback';
@@ -32,10 +33,14 @@ const MainPage = () => {
   const navigate = useNavigate();
   const { data: userList } = useOnlineUsers();
   const { data: userData, isPending, error } = useAuthCheck();
+  const { roomInfo, setRoomInfo } = useRoomInfoStore();
 
   const [selectedGameMode, setSelectedGameMode] =
     useState<FilteredGameModeType>('ALL');
 
+  useEffect(() => {
+    roomInfo && setRoomInfo(null);
+  }, []);
   if (isPending) {
     return <div>유저 정보 불러오는중...</div>;
   }

--- a/src/store/useRoomInfoStore.ts
+++ b/src/store/useRoomInfoStore.ts
@@ -5,14 +5,14 @@ interface I_useRoomState {
   roomId: number;
   roomInfo: I_RoomInfo | null;
   setRoomId: (roomId: number) => void;
-  setRoomInfo: (roomInfo: I_RoomInfo) => void;
+  setRoomInfo: (roomInfo: I_RoomInfo | null) => void;
 }
 
 const useRoomInfoStore = create<I_useRoomState>((set) => ({
   roomId: 0,
   roomInfo: null,
   setRoomId: (roomId: number) => set({ roomId }),
-  setRoomInfo: (roomInfo: I_RoomInfo) => set({ roomInfo }),
+  setRoomInfo: (roomInfo: I_RoomInfo | null) => set({ roomInfo }),
 }));
 
 export default useRoomInfoStore;


### PR DESCRIPTION
## 📋 Issue Number
close #244 

## 💻 구현 내용

- 인게임 도중 이탈하여 /main에 온경우 선택한방이 없으므로 roomInfo를 초기화합니다.

## 📷 Screenshots


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
* 모달 내부에서 처리하려고 하니까 roomInfo를 받아오고 set하는게 겹쳐서 조건이 많아지더라구요, 그래서 main에서 처리해보았습니다.

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
