### PR TITLE
[Fix] UI 개선 - GamePage

### DIFF
--- a/src/common/Header/Header.tsx
+++ b/src/common/Header/Header.tsx
@@ -4,8 +4,8 @@ import {
   SpeakerLoudIcon,
   SpeakerOffIcon,
 } from '@radix-ui/react-icons';
-import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import bgmFile from '@/assets/audio/bgm1.mp3';
 import kakao from '@/assets/login/kakao-icon.svg';
 import logo_car from '@/assets/logo/logo_car.png';
@@ -13,6 +13,7 @@ import logo_taza from '@/assets/logo/logo_taza.png';
 import { PAUSE, PLAY } from '@/common/Header/constants/volume';
 import { exchangeVolumeState } from '@/common/Header/utils/exchangeVolumeState';
 import { useAuthCheck, useLogout } from '@/hooks/useAuth/useAuth';
+import DisconnectModal from '@/pages/GamePage/common/DisconnectModal';
 import { handleKakaoLogin } from '@/utils/handleKakaoLogin';
 import WrappedIcon from '../WrappedIcon/WrappedIcon';
 import AudioPopover from './AudioPopover';
@@ -44,10 +45,14 @@ const Header = () => {
   };
 
   const [volume, setVolume] = useState<I_VolumeState>(initializeVolumeState());
+  const [isAlert, setIsAlert] = useState(false);
 
   const audioRef = useRef<HTMLAudioElement>(null);
 
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  const isGameRoute = pathname === '/game';
 
   const { data } = useAuthCheck();
 
@@ -61,6 +66,19 @@ const Header = () => {
   const handleLogout = () => {
     mutateLogout();
   };
+
+  const handleClickLogo = useCallback(() => {
+    setIsAlert(true);
+  }, []);
+
+  const handleClickCancel = useCallback(() => {
+    setIsAlert(false);
+  }, []);
+
+  const onNavigateToMain = useCallback(() => {
+    navigate('/main', { replace: true });
+    navigate(0);
+  }, []);
 
   useEffect(() => {
     sessionStorage.setItem(VOLUME_STATE_KEY, JSON.stringify(volume));
@@ -78,77 +96,80 @@ const Header = () => {
   }, [volume.volumeSize, volume.bgm]);
 
   return (
-    <header className='h-[4.5rem] w-[100%] shrink-0 flex justify-between px-[4rem]'>
-      <section
-        onClick={() => {
-          navigate('./main');
-          navigate(0);
-        }}
-        className='flex cursor-pointer items-center'>
-        <img
-          src={logo_car}
-          className='h-[70%]'
-          alt='차량 로고이미지'
-        />
-        <img
-          src={logo_taza}
-          className='h-4/6'
-          alt='티키타자'
-        />
-      </section>
-      <section className='h-full flex items-center justify-around w-[20rem]'>
-        <button
-          onClick={() =>
-            setVolume({ ...volume, bgm: exchangeVolumeState(volume.bgm) })
-          }
-          className={`bg-beige-10 hover:shadow-hover flex items-center justify-center p-[1.2rem] rounded-[1rem] transition-all duration-300 ${volume.bgm === 'pause' ? 'shadow-default' : 'shadow-hover'}`}>
-          <WrappedIcon IconComponent={mappedIcons.bgm[volume.bgm]} />
-        </button>
-        <AudioPopover
-          value={volume.volumeSize}
-          onChange={(value) => setVolume({ ...volume, volumeSize: value })}>
+    <>
+      <DisconnectModal
+        isOpen={isAlert}
+        handleClickCancel={handleClickCancel}
+      />
+      <header className='h-[4.5rem] w-[100%] shrink-0 flex justify-between px-[4rem]'>
+        <section
+          onClick={isGameRoute ? handleClickLogo : onNavigateToMain}
+          className='flex cursor-pointer items-center'>
+          <img
+            src={logo_car}
+            className='h-[70%]'
+            alt='차량 로고이미지'
+          />
+          <img
+            src={logo_taza}
+            className='h-4/6'
+            alt='티키타자'
+          />
+        </section>
+        <section className='h-full flex items-center justify-around w-[20rem]'>
           <button
-            className={`bg-beige-10 hover:shadow-hover flex items-center justify-center p-[1.2rem] rounded-[1rem] transition-all duration-300`}>
-            <WrappedIcon
-              IconComponent={
-                mappedIcons.volumeSize[volume.volumeSize > 0 ? PLAY : PAUSE]
-              }
-            />
+            onClick={() =>
+              setVolume({ ...volume, bgm: exchangeVolumeState(volume.bgm) })
+            }
+            className={`bg-beige-10 hover:shadow-hover flex items-center justify-center p-[1.2rem] rounded-[1rem] transition-all duration-300 ${volume.bgm === 'play' ? 'shadow-default' : 'shadow-hover'}`}>
+            <WrappedIcon IconComponent={mappedIcons.bgm[volume.bgm]} />
           </button>
-        </AudioPopover>
-
-        {data ? (
-          data.data.data?.isGuest ? (
-            <KakaoTooltip>
-              <img
-                src={kakao}
-                alt='Kakao logo'
-                className='w-[3rem] cursor-pointer'
-                onClick={handleKakaoLogin}
-              />
-            </KakaoTooltip>
-          ) : (
+          <AudioPopover
+            value={volume.volumeSize}
+            onChange={(value) => setVolume({ ...volume, volumeSize: value })}>
             <button
-              onClick={handleLogout}
-              className='hover:bg-gray-100 flex items-center justify-center'>
-              로그아웃
-            </button> // 카카오 로그인
-          )
-        ) : (
-          <></>
-        )}
-        <div style={{ display: 'none' }}>
-          {volume.bgm === PLAY ? (
-            <audio
-              ref={audioRef}
-              src={bgmFile}
-              autoPlay
-              loop
-            />
-          ) : null}
-        </div>
-      </section>
-    </header>
+              className={`bg-beige-10 hover:shadow-hover flex items-center justify-center p-[1.2rem] rounded-[1rem] transition-all duration-300`}>
+              <WrappedIcon
+                IconComponent={
+                  mappedIcons.volumeSize[volume.volumeSize > 0 ? PLAY : PAUSE]
+                }
+              />
+            </button>
+          </AudioPopover>
+
+          {data ? (
+            data.data.data?.isGuest ? (
+              <KakaoTooltip>
+                <img
+                  src={kakao}
+                  alt='Kakao logo'
+                  className='w-[3rem] cursor-pointer'
+                  onClick={handleKakaoLogin}
+                />
+              </KakaoTooltip>
+            ) : (
+              <button
+                onClick={handleLogout}
+                className='hover:bg-gray-100 flex items-center justify-center'>
+                로그아웃
+              </button> // 카카오 로그인
+            )
+          ) : (
+            <></>
+          )}
+          <div style={{ display: 'none' }}>
+            {volume.bgm === PLAY ? (
+              <audio
+                ref={audioRef}
+                src={bgmFile}
+                autoPlay
+                loop
+              />
+            ) : null}
+          </div>
+        </section>
+      </header>
+    </>
   );
 };
 

--- a/src/common/Header/Header.tsx
+++ b/src/common/Header/Header.tsx
@@ -13,7 +13,6 @@ import logo_taza from '@/assets/logo/logo_taza.png';
 import { PAUSE, PLAY } from '@/common/Header/constants/volume';
 import { exchangeVolumeState } from '@/common/Header/utils/exchangeVolumeState';
 import { useAuthCheck, useLogout } from '@/hooks/useAuth/useAuth';
-import DisconnectModal from '@/pages/GamePage/common/DisconnectModal';
 import { handleKakaoLogin } from '@/utils/handleKakaoLogin';
 import WrappedIcon from '../WrappedIcon/WrappedIcon';
 import AudioPopover from './AudioPopover';
@@ -45,7 +44,6 @@ const Header = () => {
   };
 
   const [volume, setVolume] = useState<I_VolumeState>(initializeVolumeState());
-  const [isAlert, setIsAlert] = useState(false);
 
   const audioRef = useRef<HTMLAudioElement>(null);
 
@@ -67,18 +65,13 @@ const Header = () => {
     mutateLogout();
   };
 
-  const handleClickLogo = useCallback(() => {
-    setIsAlert(true);
-  }, []);
-
-  const handleClickCancel = useCallback(() => {
-    setIsAlert(false);
-  }, []);
-
   const onNavigateToMain = useCallback(() => {
+    if (isGameRoute) {
+      return;
+    }
     navigate('/main', { replace: true });
     navigate(0);
-  }, []);
+  }, [isGameRoute]);
 
   useEffect(() => {
     sessionStorage.setItem(VOLUME_STATE_KEY, JSON.stringify(volume));
@@ -96,80 +89,74 @@ const Header = () => {
   }, [volume.volumeSize, volume.bgm]);
 
   return (
-    <>
-      <DisconnectModal
-        isOpen={isAlert}
-        handleClickCancel={handleClickCancel}
-      />
-      <header className='h-[4.5rem] w-[100%] shrink-0 flex justify-between px-[4rem]'>
-        <section
-          onClick={isGameRoute ? handleClickLogo : onNavigateToMain}
-          className='flex cursor-pointer items-center'>
-          <img
-            src={logo_car}
-            className='h-[70%]'
-            alt='차량 로고이미지'
-          />
-          <img
-            src={logo_taza}
-            className='h-4/6'
-            alt='티키타자'
-          />
-        </section>
-        <section className='h-full flex items-center justify-around w-[20rem]'>
+    <header className='h-[4.5rem] w-[100%] shrink-0 flex justify-between px-[4rem]'>
+      <section
+        onClick={onNavigateToMain}
+        className='flex cursor-pointer items-center'>
+        <img
+          src={logo_car}
+          className='h-[70%]'
+          alt='차량 로고이미지'
+        />
+        <img
+          src={logo_taza}
+          className='h-4/6'
+          alt='티키타자'
+        />
+      </section>
+      <section className='h-full flex items-center justify-around w-[20rem]'>
+        <button
+          onClick={() =>
+            setVolume({ ...volume, bgm: exchangeVolumeState(volume.bgm) })
+          }
+          className={`bg-beige-10 hover:shadow-hover flex items-center justify-center p-[1.2rem] rounded-[1rem] transition-all duration-300 ${volume.bgm === 'play' ? 'shadow-default' : 'shadow-hover'}`}>
+          <WrappedIcon IconComponent={mappedIcons.bgm[volume.bgm]} />
+        </button>
+        <AudioPopover
+          value={volume.volumeSize}
+          onChange={(value) => setVolume({ ...volume, volumeSize: value })}>
           <button
-            onClick={() =>
-              setVolume({ ...volume, bgm: exchangeVolumeState(volume.bgm) })
-            }
-            className={`bg-beige-10 hover:shadow-hover flex items-center justify-center p-[1.2rem] rounded-[1rem] transition-all duration-300 ${volume.bgm === 'play' ? 'shadow-default' : 'shadow-hover'}`}>
-            <WrappedIcon IconComponent={mappedIcons.bgm[volume.bgm]} />
+            className={`bg-beige-10 hover:shadow-hover flex items-center justify-center p-[1.2rem] rounded-[1rem] transition-all duration-300`}>
+            <WrappedIcon
+              IconComponent={
+                mappedIcons.volumeSize[volume.volumeSize > 0 ? PLAY : PAUSE]
+              }
+            />
           </button>
-          <AudioPopover
-            value={volume.volumeSize}
-            onChange={(value) => setVolume({ ...volume, volumeSize: value })}>
-            <button
-              className={`bg-beige-10 hover:shadow-hover flex items-center justify-center p-[1.2rem] rounded-[1rem] transition-all duration-300`}>
-              <WrappedIcon
-                IconComponent={
-                  mappedIcons.volumeSize[volume.volumeSize > 0 ? PLAY : PAUSE]
-                }
-              />
-            </button>
-          </AudioPopover>
+        </AudioPopover>
 
-          {data ? (
-            data.data.data?.isGuest ? (
-              <KakaoTooltip>
-                <img
-                  src={kakao}
-                  alt='Kakao logo'
-                  className='w-[3rem] cursor-pointer'
-                  onClick={handleKakaoLogin}
-                />
-              </KakaoTooltip>
-            ) : (
-              <button
-                onClick={handleLogout}
-                className='hover:bg-gray-100 flex items-center justify-center'>
-                로그아웃
-              </button> // 카카오 로그인
-            )
-          ) : (
-            <></>
-          )}
-          <div style={{ display: 'none' }}>
-            {volume.bgm === PLAY ? (
-              <audio
-                ref={audioRef}
-                src={bgmFile}
-                autoPlay
-                loop
+        {data ? (
+          data.data.data?.isGuest ? (
+            <KakaoTooltip>
+              <img
+                src={kakao}
+                alt='Kakao logo'
+                className='w-[3rem] cursor-pointer'
+                onClick={handleKakaoLogin}
               />
-            ) : null}
-          </div>
-        </section>
-      </header>
-    </>
+            </KakaoTooltip>
+          ) : (
+            <button
+              onClick={handleLogout}
+              className='hover:bg-gray-100 flex items-center justify-center'>
+              로그아웃
+            </button> // 카카오 로그인
+          )
+        ) : (
+          <></>
+        )}
+        <div style={{ display: 'none' }}>
+          {volume.bgm === PLAY ? (
+            <audio
+              ref={audioRef}
+              src={bgmFile}
+              autoPlay
+              loop
+            />
+          ) : null}
+        </div>
+      </section>
+    </header>
   );
 };
 

--- a/src/common/Header/Header.tsx
+++ b/src/common/Header/Header.tsx
@@ -109,7 +109,7 @@ const Header = () => {
           onClick={() =>
             setVolume({ ...volume, bgm: exchangeVolumeState(volume.bgm) })
           }
-          className={`bg-beige-10 hover:shadow-hover flex items-center justify-center p-[1.2rem] rounded-[1rem] transition-all duration-300 ${volume.bgm === 'play' ? 'shadow-default' : 'shadow-hover'}`}>
+          className={`bg-beige-10 hover:shadow-hover flex items-center justify-center p-[1.2rem] rounded-[1rem] transition-all duration-300 ${volume.bgm === 'pause' ? 'shadow-default' : 'shadow-hover'}`}>
           <WrappedIcon IconComponent={mappedIcons.bgm[volume.bgm]} />
         </button>
         <AudioPopover

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -37,6 +37,29 @@ const GamePage = () => {
   );
 
   useEffect(() => {
+    const preventKeyboardRefresh = (event: KeyboardEvent) => {
+      if (
+        event.key === 'F5' ||
+        (event.metaKey && event.key === 'r') ||
+        (event.ctrlKey && event.key === 'r')
+      ) {
+        event.preventDefault();
+      }
+    };
+    const preventMouseRefresh = (event: MouseEvent) => {
+      event.preventDefault();
+    };
+
+    window.addEventListener('keydown', preventKeyboardRefresh);
+    window.addEventListener('contextmenu', preventMouseRefresh);
+
+    return () => {
+      window.removeEventListener('keydown', preventKeyboardRefresh);
+      window.removeEventListener('contextmenu', preventMouseRefresh);
+    };
+  }, []);
+
+  useEffect(() => {
     if (gameRoomRes?.roomInfo) {
       setRoomInfo(gameRoomRes.roomInfo);
     }

--- a/src/pages/GamePage/GameWaitingRoom/GameReadyAndStart.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameReadyAndStart.tsx
@@ -7,7 +7,7 @@ import {
 interface GameReadyAndStartProps {
   isAdmin: boolean;
   userId: number;
-  allMembers: I_AllMember[] | undefined;
+  allMembers: I_AllMember[];
   handlePubReadyGame: HandlePubReadyGameType;
   handlePubStartGame: HandlePubStartGameType;
 }
@@ -20,10 +20,10 @@ const GameReadyAndStart = ({
   handlePubStartGame,
 }: GameReadyAndStartProps) => {
   const isAllUserReady =
-    allMembers?.every((user) => user.readyStatus === true) &&
-    allMembers?.length !== 1;
+    allMembers.every((user) => user.readyStatus === true) &&
+    allMembers.length !== 1;
 
-  const isUserReady = allMembers?.find(
+  const isUserReady = allMembers.find(
     ({ memberId }) => memberId === userId
   )?.readyStatus;
 

--- a/src/pages/GamePage/GameWaitingRoom/GameReadyAndStart.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameReadyAndStart.tsx
@@ -6,6 +6,7 @@ import {
 
 interface GameReadyAndStartProps {
   isAdmin: boolean;
+
   allMembers: I_AllMember[] | undefined;
   handlePubReadyGame: HandlePubReadyGameType;
   handlePubStartGame: HandlePubStartGameType;
@@ -13,6 +14,7 @@ interface GameReadyAndStartProps {
 
 const GameReadyAndStart = ({
   isAdmin,
+
   allMembers,
   handlePubReadyGame,
   handlePubStartGame,
@@ -49,7 +51,16 @@ bg-coral-50
       onClick={() => {
         handlePubReadyGame();
       }}
-      className={`w-[24.1rem] h-[10rem] flex justify-center items-center text-[2rem] bg-coral-50 hover:bg-coral-100 transition-all duration-300 shadow-md shadow-black/50 rounded-[2.5rem]`}>
+      className={`group w-[24.1rem] h-[10rem] flex justify-center items-center text-[2rem] bg-coral-50
+        relative overflow-hidden
+        shadow-md shadow-black/50 z-[0] 
+        `}>
+      <span
+        className='absolute box-border transition-all ease-in-out duration-500 z-[-1] w-0 h-0 border-0 border-solid rotate-[360deg] 
+            bottom-0 left-0 border-t-transparent border-r-transparent border-b-transparent border-l-coral-100 group-hover:border-y-[10rem] group-hover:border-x-[calc(25.3rem*1.05)]'></span>
+      <span
+        className='absolute box-border transition-all ease-in-out duration-500 z-[-1] w-0 h-0 border-0 border-solid rotate-[360deg] 
+      top-0 right-0 border-t-transparent border-r-coral-100 border-b-transparent border-l-transparent group-hover:border-y-[10rem] group-hover:border-x-[calc(25.3rem*1.05)]'></span>
       준비
     </button>
   );

--- a/src/pages/GamePage/GameWaitingRoom/GameReadyAndStart.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameReadyAndStart.tsx
@@ -27,9 +27,19 @@ const GameReadyAndStart = ({
         onClick={() => {
           isAllUserReady && handlePubStartGame();
         }}
-        className={`w-[24.1rem] h-[10rem] flex justify-center items-center text-[2rem] transition-all duration-300 shadow-md shadow-black/50 rounded-[2.5rem]
-        ${isAllUserReady ? `bg-coral-100` : `bg-coral-50 opacity-[0.5] cursor-not-allowed`}
+        className={`w-[24.1rem] h-[10rem] flex justify-center items-center text-[2rem] transition-all duration-300 shadow-md shadow-black/50 relative
+overflow-hidden
+bg-coral-50
+        ${isAllUserReady ? ` hover:bg-coral-100` : `opacity-[0.5] cursor-not-allowed`}
         `}>
+        {isAllUserReady && (
+          <>
+            <span className='absolute block top-0 left-0 w-full h-[0.3rem] bg-gradient-to-l from-coral-100 animate-neonTop'></span>
+            <span className='absolute block top-[-100%] right-0 w-[0.3rem] h-full bg-gradient-to-t from-coral-100 animate-neonRight'></span>
+            <span className='absolute block bottom-0 right-0 w-full h-[0.3rem] bg-gradient-to-r from-coral-100 animate-neonBottom'></span>
+            <span className='absolute block bottom-[-100%] left-0 w-[0.3rem] h-full bg-gradient-to-b from-coral-100 animate-neonLeft'></span>
+          </>
+        )}
         시작
       </button>
     );

--- a/src/pages/GamePage/GameWaitingRoom/GameReadyAndStart.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameReadyAndStart.tsx
@@ -6,7 +6,7 @@ import {
 
 interface GameReadyAndStartProps {
   isAdmin: boolean;
-
+  userId: number;
   allMembers: I_AllMember[] | undefined;
   handlePubReadyGame: HandlePubReadyGameType;
   handlePubStartGame: HandlePubStartGameType;
@@ -14,7 +14,7 @@ interface GameReadyAndStartProps {
 
 const GameReadyAndStart = ({
   isAdmin,
-
+  userId,
   allMembers,
   handlePubReadyGame,
   handlePubStartGame,
@@ -22,6 +22,10 @@ const GameReadyAndStart = ({
   const isAllUserReady =
     allMembers?.every((user) => user.readyStatus === true) &&
     allMembers?.length !== 1;
+
+  const isUserReady = allMembers?.find(
+    ({ memberId }) => memberId === userId
+  )?.readyStatus;
 
   if (isAdmin) {
     return (
@@ -51,7 +55,7 @@ bg-coral-50
       onClick={() => {
         handlePubReadyGame();
       }}
-      className={`group w-[24.1rem] h-[10rem] flex justify-center items-center text-[2rem] bg-coral-50
+      className={`group w-[24.1rem] h-[10rem] flex justify-center items-center text-[2rem] ${isUserReady ? 'bg-coral-100' : 'bg-coral-50'}
         relative overflow-hidden
         shadow-md shadow-black/50 z-[0] 
         `}>

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomLinkInvitation.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomLinkInvitation.tsx
@@ -1,6 +1,7 @@
 const GameRoomLinkInvitation = () => {
+  //TODO : 링크 초대 기능 구현
   return (
-    <button className='w-[24.1rem] h-[10rem] flex justify-center items-center text-[2rem] bg-coral-50 hover:bg-coral-100 transition-all duration-300 shadow-md shadow-black/50 rounded-[2.5rem]'>
+    <button className='invisible w-[24.1rem] h-[10rem] flex justify-center items-center text-[2rem] bg-coral-50 hover:bg-coral-100 transition-all duration-300 shadow-md shadow-black/50 rounded-[2.5rem]'>
       링크 초대
     </button>
   );

--- a/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameRoomUserItem.tsx
@@ -29,7 +29,7 @@ const GameRoomUserItem = ({
 
   return (
     <div
-      className={`w-[25.8rem] h-[21.2rem] p-[1.6rem] pb-[4rem] relative flex flex-col shadow-md shadow-black/50 rounded-[2.5rem] ${isMe ? 'bg-beige-100' : 'bg-white'}`}>
+      className={`w-[25.8rem] h-[21.2rem] p-[1.6rem] pb-[4rem] relative flex flex-col shadow-lg shadow-black/50 rounded-[2.5rem] bg-white outline ${isMe ? 'border-4 border-green-100 outline-black' : 'outline-gray-100'} `}>
       <div className='h-[3rem] self-end'>
         <button
           onClick={() => {
@@ -52,9 +52,8 @@ const GameRoomUserItem = ({
         />
         <div className='w-1/2 flex flex-col justify-evenly text-center'>
           <div
-            className={`w-[10rem] ${isMe ? 'h-[5rem]' : 'h-[3rem]'} py-[0.4rem] bg-green-70 rounded-[1rem]`}>
+            className={`w-[10rem] h-[3rem] py-[0.4rem] bg-green-70 rounded-[1rem]`}>
             {nickname}
-            {isMe && ' (본인)'}
           </div>
           <div className='w-[10rem] h-[3rem] py-[0.4rem] bg-green-70 rounded-[1rem] text-[1.4rem]'>
             {ranking === -1
@@ -66,7 +65,8 @@ const GameRoomUserItem = ({
         </div>
       </div>
       {((isAdminMe && isMe) || isReady) && (
-        <div className='absolute w-[13rem] h-[4rem] rounded-[2rem_0_2.5rem] right-0 bottom-0 text-center leading-[4rem] font-[Giants-Inline] bg-green-100'>
+        <div
+          className={`absolute w-[13rem] h-[4rem] rounded-[2rem_0_2.5rem] ${isMe ? 'right-[-2px] bottom-[-2px]' : 'right-[-1px] bottom-[-1px]'}  text-center leading-[4rem] font-[Giants-Inline] bg-green-100`}>
           {isAdmin ? '방장' : isReady && '준비'}
         </div>
       )}

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -83,6 +83,7 @@ const GameWaitingRoom = ({
           <GameRoomLinkInvitation />
           <GameReadyAndStart
             isAdmin={isAdmin}
+            userId={userId}
             allMembers={allMembers}
             handlePubReadyGame={handlePubReadyGame}
             handlePubStartGame={handlePubStartGame}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,9 +36,45 @@ export default {
         blinkTimer: {
           '50%': { color: 'red' },
         },
+        neonTop: {
+          '0%': {
+            left: '-100%',
+          },
+          '50%, 100%': {
+            left: '100%',
+          },
+        },
+        neonRight: {
+          '0%': {
+            top: '-100%',
+          },
+          '50%, 100%': {
+            top: '100%',
+          },
+        },
+        neonBottom: {
+          '0%': {
+            right: '-100%',
+          },
+          '50%, 100%': {
+            right: '100%',
+          },
+        },
+        neonLeft: {
+          '0%': {
+            bottom: '-100%',
+          },
+          '50%, 100%': {
+            bottom: '100%',
+          },
+        },
       },
       animation: {
         blinkTimer: 'blinkTimer 1s ease-in-out infinite',
+        neonTop: 'neonTop 1s linear infinite 0s',
+        neonRight: 'neonRight 1s linear infinite 0.25s',
+        neonBottom: 'neonBottom 1s linear infinite 0.5s',
+        neonLeft: 'neonLeft 1s linear infinite 0.75s',
       },
       backgroundImage: {
         'gradient-radial':


### PR DESCRIPTION
## 📋 Issue Number
close #

## 💻 구현 내용
- [x] /game 라우트 일 때 헤더의 로고 누르면 아무 기능 없도록 변경
- [x] /game 라우트 일 때 새로고침 키보드, 마우스 우클릭 이벤트 막기

시작 버튼
- 모두가 준비 되면 네온 효과 유지
- 모두가 준비 아니면 네온 효과 역으로 재생

준비 버튼
- 준비 버튼 누르면 slice 효과
- 다시 눌러서 취소 되면 효과 역으로 재생
## 📷 Screenshots

<img width="266" alt="스크린샷 2024-03-19 오전 9 35 06" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/02a6e2d7-03a5-4c70-b161-2ae4452b9b75">

https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/94d604cd-9530-48b7-851e-2e6589f292cc




## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점
/game 라우트 일 때(게임방, 인게임) 헤더의 로고를 클릭하면 DisconnectModal을 통해 메인 화면으로 나갈 수 있습니다. 
문제는 보시다시피 DisconnectModal이 사라지고 메인화면이 나타나는 것이 아니라, **메인화면이 나타나고 DisconnectModal이 사라집니다**.
어떻게 해결할 수 있을까요..?! 🤔  -> /game 라우트 일 때 헤더의 로고 누르면 아무 기능 없도록 변경 -->
<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
