### PR TITLE
[Fix] 아무도 타이핑하지 않을시 2라운드 후 타이머 돌아가지 않는 버그 수정

### DIFF
--- a/src/pages/GamePage/IngameWebsocketLayer.tsx
+++ b/src/pages/GamePage/IngameWebsocketLayer.tsx
@@ -38,7 +38,7 @@ const IngameWebsocketLayer = ({
     ) {
       setIsRoundWaiting(true);
     }
-  }, [ingameRoomRes.type]);
+  }, [ingameRoomRes]);
 
   if (isIngameWsError || checkIsEmptyObj(ingameRoomRes)) {
     return <WsError />;


### PR DESCRIPTION
## 📋 Issue Number
close #249 

## 💻 구현 내용

- 2라운드 이후 타이머가 돌아가지 않는 버그를 수정하였습니다
- `useEffect` 의존성 배열에 `ingameRoomRes.type`이 들어가있는데, 전원 입력하지 않을시 2라운드부터 `NEXT_ROUND_START`만 들어오기 때문에 `isRoundWaiting`이 업데이트되지 않아서 타이머가 돌아가지 않았었습니다
