### PR TITLE
[Style] 라운드 종료 5초 전부터 타이머 깜빡임

### DIFF
--- a/src/common/Ingame/IngameHeader.tsx
+++ b/src/common/Ingame/IngameHeader.tsx
@@ -63,7 +63,8 @@ const IngameHeader = ({
         <div className='w-[40rem] truncate text-[4rem]'>{roomInfo?.title}</div>
         <div className='grow'>참여 {roomInfo?.currentPlayer}명</div>
         <div>
-          <span className='font-bold font-[Giants-Inline] text-[3.2rem]'>
+          <span
+            className={`font-bold font-[Giants-Inline] text-[3.2rem] ${timeLeft <= 5000 && 'animate-blinkTimer'}`}>
             남은 시간 : {convertTime(timeLeft)}
           </span>
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,6 +33,12 @@ export default {
             opacity: 1,
           },
         },
+        blinkTimer: {
+          '50%': { color: 'red' },
+        },
+      },
+      animation: {
+        blinkTimer: 'blinkTimer 1s ease-in-out infinite',
       },
       backgroundImage: {
         'gradient-radial':
@@ -48,4 +54,3 @@ export default {
   },
   plugins: [scrollbarHide],
 };
-// foo: 'radial-gradient(rgba(200,0,0,0.40) 0%, rgba(255,0,255,0.00) 100%), conic-gradient(from -90deg, #96D8BF 30deg, #6aab93 0 60deg, #40806A 0 90deg, #135743 0 120deg, #003120 0 150deg, #000000 0 180deg, #0000 0)',


### PR DESCRIPTION
## 📋 Issue Number
close # 221

## 💻 구현 내용

- 라운드 종료 5초전부터 타이머가 깜빡입니다

https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/81412212/877c940a-402e-4c7b-8ac0-1ccafd209244


## 📷 Screenshots


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
* 색상, 몇초후부터 깜빡일지

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
