### PR TITLE
[Style] 자동차 트랙 위 좌표수정 및 스타일링 수정

### DIFF
--- a/src/common/Header/Header.tsx
+++ b/src/common/Header/Header.tsx
@@ -101,7 +101,7 @@ const Header = () => {
           onClick={() =>
             setVolume({ ...volume, bgm: exchangeVolumeState(volume.bgm) })
           }
-          className={`bg-beige-10 hover:shadow-hover flex items-center justify-center p-[1.2rem] rounded-[1rem] transition-all duration-300 ${volume.bgm === 'play' ? 'shadow-default' : 'shadow-hover'}`}>
+          className={`bg-beige-10 hover:shadow-hover flex items-center justify-center p-[1.2rem] rounded-[1rem] transition-all duration-300 ${volume.bgm === 'pause' ? 'shadow-default' : 'shadow-hover'}`}>
           <WrappedIcon IconComponent={mappedIcons.bgm[volume.bgm]} />
         </button>
         <AudioPopover

--- a/src/common/Layout/BodyLayout.tsx
+++ b/src/common/Layout/BodyLayout.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 
 const BodyLayout = ({ children }: { children: ReactNode }) => {
   return (
-    <div className='w-layout-w px-[2rem] py-[2rem] mt-[1rem] flex flex-col bg-bodyLayoutBgColor rounded-[1rem]'>
+    <div className='w-layout-w h-[68.5rem] box-content px-[2rem] py-[2rem] mt-[1rem] flex flex-col bg-bodyLayoutBgColor rounded-[1rem]'>
       {children}
     </div>
   );

--- a/src/pages/GamePage/GameCode/CodeForm.tsx
+++ b/src/pages/GamePage/GameCode/CodeForm.tsx
@@ -157,8 +157,8 @@ const CodeForm = ({
             <>
               {[...codeItem].map((char, idx) => (
                 <span
-                  className={`${checkedCorrectAndTypo[idx] === CHAR_STATE.CORRECT ? 'text-black font-bold' : checkedCorrectAndTypo[idx] === CHAR_STATE.TYPO ? 'text-red-500 font-bold' : 'text-white'} 
-                ${char === ' ' && checkedCorrectAndTypo[idx] === 'typo' && 'w-[0.5rem] h-[2rem] bg-red-500'}`}
+                  className={`${checkedCorrectAndTypo[idx] === CHAR_STATE.CORRECT ? 'text-black' : checkedCorrectAndTypo[idx] === CHAR_STATE.TYPO ? 'text-red-700' : 'text-white'} 
+                ${char === ' ' && checkedCorrectAndTypo[idx] === 'typo' && 'w-[0.5rem] h-[2rem] bg-red-700'}`}
                   key={`${char}${idx}`}>
                   {char === ' ' ? '\u00A0' : char}
                 </span>

--- a/src/pages/GamePage/GameCode/GameCode.tsx
+++ b/src/pages/GamePage/GameCode/GameCode.tsx
@@ -3,6 +3,7 @@ import IngameHeader from '@/common/Ingame/IngameHeader';
 import IngameRank from '@/common/Ingame/IngameRank';
 import useIngameStore from '@/store/useIngameStore';
 import CanvasTrack from '../common/CanvasTrack';
+import TrackLine from '../common/TrackLine';
 import useGameRound from '../hooks/useGameRound';
 import { I_Question, PublishIngameType } from '../types/websocketType';
 import CodeContainer from './CodeContainer';
@@ -89,8 +90,7 @@ const GameCode = ({ publishIngame, userId }: GameCodeProps) => {
           <IngameRank rankInfos={rankInfoList} />
         </div>
         <div className='flex flex-col items-center justify-center ml-80 h-[61rem] relative w-[110rem]'>
-          <div className='absolute w-[110rem] h-full rounded-[10rem] border-2 border-black'></div>
-          <div className='absolute w-[100rem] h-[calc(100%-10rem)] rounded-[5rem] border-2 border-black'></div>
+          <TrackLine />
           <CanvasTrack allMembers={ingameRoomRes.allMembers} />
           <CodeFormContainer
             key={codeList.current[0].question}

--- a/src/pages/GamePage/GameFinish/GameFinish.tsx
+++ b/src/pages/GamePage/GameFinish/GameFinish.tsx
@@ -98,14 +98,14 @@ const GameFinish = ({
             navigate('/main', { replace: true });
             navigate(0);
           }}
-          className='bg-coral-100 px-6 py-6 rounded-[1rem] text-[3rem] font-bold'>
+          className='bg-coral-100 px-6 py-6 rounded-[1rem] text-[2rem] font-bold'>
           로비로 나가기
         </button>
         <button
           onClick={() => {
             onMoveToGameRoom();
           }}
-          className='bg-coral-100 px-6 py-6 rounded-[1rem] text-[3rem] font-bold'>
+          className='bg-coral-100 px-6 py-6 rounded-[1rem] text-[2rem] font-bold'>
           다시하기
         </button>
       </section>

--- a/src/pages/GamePage/GameSentence/GameSentence.tsx
+++ b/src/pages/GamePage/GameSentence/GameSentence.tsx
@@ -3,6 +3,7 @@ import IngameHeader from '@/common/Ingame/IngameHeader';
 import IngameRank from '@/common/Ingame/IngameRank';
 import useIngameStore from '@/store/useIngameStore';
 import CanvasTrack from '../common/CanvasTrack';
+import TrackLine from '../common/TrackLine';
 import useGameRound from '../hooks/useGameRound';
 import { I_Question, PublishIngameType } from '../types/websocketType';
 import GameFormContainer from './GameFormContainer';
@@ -86,8 +87,7 @@ const GameSentence = ({ publishIngame, userId }: GameSentenceProps) => {
           <IngameRank rankInfos={rankInfoList} />
         </div>
         <div className='flex flex-col items-center justify-center ml-80 h-[61rem] relative w-[110rem]'>
-          <div className='absolute w-[110rem] h-full rounded-[10rem] border-2 border-black'></div>
-          <div className='absolute w-[100rem] h-[calc(100%-10rem)] rounded-[5rem] border-2 border-black'></div>
+          <TrackLine />
           <CanvasTrack allMembers={ingameRoomRes.allMembers} />
           <GameFormContainer
             sentenceList={sentenceList.current}

--- a/src/pages/GamePage/common/CanvasTrack.tsx
+++ b/src/pages/GamePage/common/CanvasTrack.tsx
@@ -13,7 +13,6 @@ import {
   SOUTH_LAST_SCORE,
   SOUTH_START_X,
   START_X,
-  TRACK_WIDHT,
   WEST_LAST_SCORE,
   WEST_START_Y,
 } from '@/common/Ingame/ingameConstants';
@@ -104,7 +103,7 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
           y -= CAR_SIZE;
         }
       } else if (score <= WEST_LAST_SCORE) {
-        x = TRACK_WIDHT - lineGap - CAR_SIZE;
+        x = lineGap;
         y = WEST_START_Y - MOVE_STEP_Y * (score - (SOUTH_LAST_SCORE + 1));
         if (score === WEST_LAST_SCORE) {
           x += CAR_SIZE;

--- a/src/pages/GamePage/common/CanvasTrack.tsx
+++ b/src/pages/GamePage/common/CanvasTrack.tsx
@@ -66,7 +66,7 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
     // allMembers 유저수 만큼 좌표 지정
     allMembers.forEach((member, idx) => {
       const { score } = member;
-      const lineGap = (idx % 4) * 10;
+      const lineGap = idx % 4;
 
       let x = 0;
       let y = 0;
@@ -83,13 +83,13 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
 
       if (score <= NORTH_LAST_SCORE) {
         x = START_X + MOVE_STEP_X * score;
-        y = lineGap;
+        y = lineGap * 12 - 2;
         if (score === NORTH_LAST_SCORE) {
           x -= CAR_SIZE;
           y += CAR_SIZE;
         }
       } else if (score <= EAST_LAST_SCORE) {
-        x = CANVAS_WIDTH - lineGap - CAR_SIZE;
+        x = CANVAS_WIDTH - lineGap * 10 - CAR_SIZE + 2;
         y = EAST_START_Y + MOVE_STEP_Y * (score - (NORTH_LAST_SCORE + 1));
         if (score === EAST_LAST_SCORE) {
           x -= CAR_SIZE;
@@ -97,21 +97,16 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
         }
       } else if (score <= SOUTH_LAST_SCORE) {
         x = SOUTH_START_X - MOVE_STEP_X * (score - (EAST_LAST_SCORE + 1));
-        y = CANVAS_HEIGHT - lineGap - CAR_SIZE;
-        if (score === SOUTH_LAST_SCORE) {
-          x += CAR_SIZE;
-          y -= CAR_SIZE;
-        }
+        y = CANVAS_HEIGHT - lineGap * 12 - CAR_SIZE + 5;
       } else if (score <= WEST_LAST_SCORE) {
-        x = lineGap;
+        x = lineGap * 10;
         y = WEST_START_Y - MOVE_STEP_Y * (score - (SOUTH_LAST_SCORE + 1));
         if (score === WEST_LAST_SCORE) {
-          x += CAR_SIZE;
           y += CAR_SIZE;
         }
       } else if (score > WEST_LAST_SCORE) {
         x = START_X + MOVE_STEP_X * (score - 100);
-        y = lineGap;
+        y = lineGap * 12 - 2;
       }
       carsRef.current[idx] = { x, y, idx };
       prevData.current[member.memberId] = member.score;

--- a/src/pages/GamePage/common/CanvasTrack.tsx
+++ b/src/pages/GamePage/common/CanvasTrack.tsx
@@ -67,7 +67,8 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
     allMembers.forEach((member, idx) => {
       const { score } = member;
       const lineGap = idx % 4;
-
+      const verticalLineGap = (idx % 4) * 12 - 2;
+      const horizontalLineGap = (idx % 4) * 10 + 2;
       let x = 0;
       let y = 0;
 
@@ -83,13 +84,13 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
 
       if (score <= NORTH_LAST_SCORE) {
         x = START_X + MOVE_STEP_X * score;
-        y = lineGap * 12 - 2;
+        y = verticalLineGap;
         if (score === NORTH_LAST_SCORE) {
           x -= CAR_SIZE;
           y += CAR_SIZE;
         }
       } else if (score <= EAST_LAST_SCORE) {
-        x = CANVAS_WIDTH - lineGap * 10 - CAR_SIZE + 2;
+        x = CANVAS_WIDTH - horizontalLineGap - CAR_SIZE;
         y = EAST_START_Y + MOVE_STEP_Y * (score - (NORTH_LAST_SCORE + 1));
         if (score === EAST_LAST_SCORE) {
           x -= CAR_SIZE;
@@ -97,16 +98,16 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
         }
       } else if (score <= SOUTH_LAST_SCORE) {
         x = SOUTH_START_X - MOVE_STEP_X * (score - (EAST_LAST_SCORE + 1));
-        y = CANVAS_HEIGHT - lineGap * 12 - CAR_SIZE + 5;
+        y = CANVAS_HEIGHT - verticalLineGap - CAR_SIZE + 3;
       } else if (score <= WEST_LAST_SCORE) {
-        x = lineGap * 10;
+        x = horizontalLineGap;
         y = WEST_START_Y - MOVE_STEP_Y * (score - (SOUTH_LAST_SCORE + 1));
         if (score === WEST_LAST_SCORE) {
           y += CAR_SIZE;
         }
       } else if (score > WEST_LAST_SCORE) {
         x = START_X + MOVE_STEP_X * (score - 100);
-        y = lineGap * 12 - 2;
+        y = verticalLineGap;
       }
       carsRef.current[idx] = { x, y, idx };
       prevData.current[member.memberId] = member.score;

--- a/src/pages/GamePage/common/TrackLine.tsx
+++ b/src/pages/GamePage/common/TrackLine.tsx
@@ -1,0 +1,10 @@
+const TrackLine = () => {
+  return (
+    <>
+      <div className='absolute w-[110rem] h-full rounded-[10rem] border-2 border-black'></div>
+      <div className='absolute w-[105rem] h-[calc(100%-5rem)] border-dashed rounded-[7.5rem] border-[1px] border-gray-300'></div>
+      <div className='absolute w-[100rem] h-[calc(100%-10rem)] rounded-[5rem] border-2 border-black'></div>
+    </>
+  );
+};
+export default TrackLine;

--- a/src/pages/MainPage/CreateRoom/CreateRoomForm.tsx
+++ b/src/pages/MainPage/CreateRoom/CreateRoomForm.tsx
@@ -65,7 +65,7 @@ const CreateRoomForm = ({
       title: roomInfo?.title ?? '',
       password: roomInfo?.password ?? '',
       round: roomInfo?.maxRound ?? 2,
-      maxPlayer: roomInfo?.maxPlayer ?? 2,
+      maxPlayer: roomInfo?.maxPlayer ?? 8,
     },
   });
 


### PR DESCRIPTION
## 📋 Issue Number
close # 221

## 💻 구현 내용

- 방 생성 모달에서 방입장 제한 인원 기존 2인에서 **8인**으로 수정하였습니다.
- 자동차 트랙 좌표 수정 -> 이미지는 128x128인데 그 중 실제 자동차가 정사각형 꽉차게 들어가 있는게 아니다보니 위치마다 조정이 필요했습니다.
- 코드 게임에서 , 알맞게 입력인 경우 bold처리가 되면서 주어진 문제와 입력창 글자크기 및 자간이 바뀌고 있었습니다. -> **bold 처리 삭제**  ( bold처리 필요하시면, 문제 문장 전체랑 입력창 전체에도 처리해주시면 될거같습니다

## 📷 Screenshots
![스크린샷 2024-03-18 20 56 46](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/81412212/a21e7a82-e6b1-40ab-ad7e-0f9bd6405fcf)


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 --> bold처리 모두 제외했습니다.  있는게 낫다면, 입력창까지 모두에게 bold처리를 해줘야 할것 같습니다.


<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
