### PR TITLE
[Feat] 웹소켓 연결 후 새로고침 시 /main 라우팅

### DIFF
--- a/src/common/Error/ErrorBoundaryFallback.tsx
+++ b/src/common/Error/ErrorBoundaryFallback.tsx
@@ -1,0 +1,21 @@
+import { useNavigate } from 'react-router-dom';
+
+const ErrorBoundaryFallback = () => {
+  const navigate = useNavigate();
+  const gotoMain = () => {
+    navigate('/main', { replace: true });
+    navigate(0);
+  };
+  return (
+    <div>
+      <div>게임 연결에 오류가 발생했습니다!!</div>
+      <button
+        onClick={gotoMain}
+        className='underline'>
+        {' '}
+        다시 연결하기
+      </button>
+    </div>
+  );
+};
+export default ErrorBoundaryFallback;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from './App.tsx';
 import AuthRoute from './common/AuthRoute/AuthRoute.tsx';
+import ErrorBoundaryFallback from './common/Error/ErrorBoundaryFallback.tsx';
 import Header from './common/Header/Header.tsx';
 import BodyLayout from './common/Layout/BodyLayout.tsx';
 import Layout from './common/Layout/Layout.tsx';
@@ -28,7 +29,7 @@ export const router = createBrowserRouter([
           <Layout>
             <Header />
             <BodyLayout>
-              <ErrorBoundary fallback={<div>연유를 모르는 에러</div>}>
+              <ErrorBoundary fallback={<ErrorBoundaryFallback />}>
                 <AuthRoute />
               </ErrorBoundary>
             </BodyLayout>

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -4,7 +4,6 @@ import Loading from '@/common/Loading/Loading';
 import { useAuthCheck } from '@/hooks/useAuth/useAuth';
 import useGameWaitingRoomStore from '@/store/useGameWaitingRoomStore';
 import useRoomInfoStore from '@/store/useRoomInfoStore';
-import WsError from './common/WsError';
 import GameWaitingRoom from './GameWaitingRoom/GameWaitingRoom';
 import useWebsocket from './hooks/useWebsocket';
 import IngameWebsocketLayer from './IngameWebsocketLayer';
@@ -71,7 +70,8 @@ const GamePage = () => {
   }, [gameRoomRes, isKicked]);
 
   if (!roomId || isWsError) {
-    return <WsError />;
+    navigate('/main', { replace: true });
+    navigate(0);
   }
 
   if (isError) {


### PR DESCRIPTION
## 📋 Issue Number
close #259

## 💻 구현 내용

- gamePage, ingame 에서 새로고침시 main으로 라우트 시킵니다

## 📷 Screenshots


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
  TODO: 리렌더링 트리거 방법 더 고민..

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
