### PR TITLE
[Fix] 랭킹 페이지 관련 UI 수정

### DIFF
--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -56,9 +56,11 @@ const MainPage = () => {
           userList={[...userList.data.data!]}
           myId={userData.data.data!.memberId}
         />
-        <article className='flex items-center justify-center bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[4.5rem] w-full cursor-pointer hover:bg-green-100 transition-all'>
-          <button onClick={() => navigate('/rank')}>전체 랭킹 페이지</button>
-        </article>
+        <button
+          className='flex items-center justify-center bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[4.5rem] w-full cursor-pointer hover:bg-green-100 transition-all'
+          onClick={() => navigate('/rank')}>
+          전체 랭킹 페이지
+        </button>
         <UserCard
           nickname={userData.data.data!.nickname}
           isGuest={userData.data.data!.isGuest}

--- a/src/pages/RankPage/RankPage.tsx
+++ b/src/pages/RankPage/RankPage.tsx
@@ -1,5 +1,7 @@
 import * as Tabs from '@radix-ui/react-tabs';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Backward from '@/common/Backward/Backward';
 import { useRank } from '@/hooks/useRank';
 import RankList from './RankList';
 
@@ -14,35 +16,44 @@ const RankPage = () => {
     { value: 'CODE', text: '코드' },
   ];
 
+  const navigate = useNavigate();
+
+  const handleClickBackward = useCallback(() => {
+    navigate('/main', { replace: true });
+  }, []);
+
   useEffect(() => {
     // 탭이 변경될 때마다 refetch 함수를 호출하여 랭킹 데이터를 갱신합니다.
     refetch();
   }, [selectedTab, refetch]);
 
   return (
-    <Tabs.Root
-      className='flex flex-col gap-[4rem] w-[60%] mx-auto'
-      defaultValue=''
-      onValueChange={setSelectedTab}>
-      <Tabs.List className='flex gap-[11rem] justify-center font-bold font-[Giants-Inline] text-4x'>
+    <>
+      <Backward handleClickBackward={handleClickBackward} />
+      <Tabs.Root
+        className='flex flex-col gap-[4rem] w-[60%] mx-auto'
+        defaultValue=''
+        onValueChange={setSelectedTab}>
+        <Tabs.List className='flex gap-[11rem] justify-center font-bold font-[Giants-Inline] text-4x'>
+          {tabData.map(({ value, text }) => (
+            <Tabs.Trigger
+              key={text}
+              value={value}
+              className='bg-green-70 rounded-[1rem] px-8 py-4 data-[state=active]:bg-green-100'
+              data-state={value === selectedTab ? 'active' : 'inactive'}>
+              {text}
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
         {tabData.map(({ value, text }) => (
-          <Tabs.Trigger
+          <Tabs.Content
             key={text}
-            value={value}
-            className='bg-green-70 rounded-[1rem] px-8 py-4 data-[state=active]:bg-green-100'
-            data-state={value === selectedTab ? 'active' : 'inactive'}>
-            {text}
-          </Tabs.Trigger>
+            value={value}>
+            <RankList convertedRankData={rankData.data.data} />
+          </Tabs.Content>
         ))}
-      </Tabs.List>
-      {tabData.map(({ value, text }) => (
-        <Tabs.Content
-          key={text}
-          value={value}>
-          <RankList convertedRankData={rankData.data.data} />
-        </Tabs.Content>
-      ))}
-    </Tabs.Root>
+      </Tabs.Root>
+    </>
   );
 };
 


### PR DESCRIPTION
## 📋 Issue Number
close #

## 💻 구현 내용

- 메인 화면에서 랭킹 페이지 이동 전체 클릭 가능하게 버튼으로 수정
- 전체 랭킹 페이지 내부에서 뒤로가기 추가

## 📷 Screenshots


https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/69a08e17-962d-4dca-9ff1-e554bf9cceed



## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
