### PR TITLE
[Fix] 자동차 좌표 이슈들 해결

### DIFF
--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import Backward from '@/common/Backward/Backward';
 import useCarImgStore from '@/store/useCarStore';
 import DisconnectModal from '../common/DisconnectModal';
-import { CarImgType } from '../types/ingameTypes';
+import { NumberIndexSignitureType } from '../types/ingameTypes';
 import {
   HandlePubKickUserType,
   HandlePubReadyGameType,
@@ -46,7 +46,7 @@ const GameWaitingRoom = ({
   }, []);
 
   useEffect(() => {
-    const carIdxArray: CarImgType = {};
+    const carIdxArray: NumberIndexSignitureType = {};
     allMembers.forEach((car, idx) => {
       const { memberId } = car;
       carIdxArray[memberId] = idx;

--- a/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
+++ b/src/pages/GamePage/GameWaitingRoom/GameWaitingRoom.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import Backward from '@/common/Backward/Backward';
 import useCarImgStore from '@/store/useCarStore';
 import DisconnectModal from '../common/DisconnectModal';
-import { NumberIndexSignitureType } from '../types/ingameTypes';
+import { NumberIndexSignatureType } from '../types/ingameTypes';
 import {
   HandlePubKickUserType,
   HandlePubReadyGameType,
@@ -46,7 +46,7 @@ const GameWaitingRoom = ({
   }, []);
 
   useEffect(() => {
-    const carIdxArray: NumberIndexSignitureType = {};
+    const carIdxArray: NumberIndexSignatureType = {};
     allMembers.forEach((car, idx) => {
       const { memberId } = car;
       carIdxArray[memberId] = idx;

--- a/src/pages/GamePage/common/CanvasTrack.tsx
+++ b/src/pages/GamePage/common/CanvasTrack.tsx
@@ -82,6 +82,9 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
         return;
       }
 
+      if (score > WEST_LAST_SCORE) {
+        score -= WEST_LAST_SCORE + 1;
+      }
       if (score <= NORTH_LAST_SCORE) {
         x = START_X + MOVE_STEP_X * score;
         y = verticalLineGap;
@@ -105,10 +108,11 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
         if (score === WEST_LAST_SCORE) {
           y += CAR_SIZE;
         }
-      } else if (score > WEST_LAST_SCORE) {
-        x = START_X + MOVE_STEP_X * (score - 100);
-        y = verticalLineGap;
       }
+      // else if (score > WEST_LAST_SCORE) {
+      //   x = START_X + MOVE_STEP_X * (score - 100);
+      //   y = verticalLineGap;
+      // }
       carsRef.current[memberId] = { x, y };
       idScore.current[memberId] = score;
     });

--- a/src/pages/GamePage/common/CanvasTrack.tsx
+++ b/src/pages/GamePage/common/CanvasTrack.tsx
@@ -109,10 +109,6 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
           y += CAR_SIZE;
         }
       }
-      // else if (score > WEST_LAST_SCORE) {
-      //   x = START_X + MOVE_STEP_X * (score - 100);
-      //   y = verticalLineGap;
-      // }
       carsRef.current[memberId] = { x, y };
       idScore.current[memberId] = score;
     });

--- a/src/pages/GamePage/common/CanvasTrack.tsx
+++ b/src/pages/GamePage/common/CanvasTrack.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/common/Ingame/ingameConstants';
 import useCanvas from '@/hooks/useCanvas';
 import useCarImgStore from '@/store/useCarStore';
-import { CarImgType } from '../types/ingameTypes';
+import { NumberIndexSignitureType } from '../types/ingameTypes';
 import { I_AllMember } from '../types/websocketType';
 
 interface I_CarCoord {
@@ -38,7 +38,8 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
   });
   const { carImgStore } = useCarImgStore();
 
-  const prevData = useRef<CarImgType>({});
+  // console.log('IINI', initialValue.current);
+  const prevData = useRef<NumberIndexSignitureType>({});
   const carImagesRef = useRef<HTMLImageElement[] | null>(null);
   const carsRef = useRef<I_CarCoord[]>([]);
   carsRef.current = [];

--- a/src/pages/GamePage/common/CanvasTrack.tsx
+++ b/src/pages/GamePage/common/CanvasTrack.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { useEffect, useRef } from 'react';
 import { TRACK_CARS } from '@/assets/canvasCars';
 import {
@@ -18,6 +17,7 @@ import {
 } from '@/common/Ingame/ingameConstants';
 import useCanvas from '@/hooks/useCanvas';
 import useCarImgStore from '@/store/useCarStore';
+import { NumberIndexSignatureType } from '../types/ingameTypes';
 import { I_AllMember } from '../types/websocketType';
 
 interface I_CarCoord {
@@ -35,8 +35,8 @@ const CanvasTrack = ({ allMembers }: { allMembers: I_AllMember[] }) => {
   });
   const { carImgStore } = useCarImgStore();
 
-  const idScore = useRef<{ [key: number]: number }>(
-    allMembers.reduce((object: { [key: number]: number }, value) => {
+  const idScore = useRef<NumberIndexSignatureType>(
+    allMembers.reduce((object: NumberIndexSignatureType, value) => {
       object[value.memberId] = value.score;
       return object;
     }, {})

--- a/src/pages/GamePage/types/ingameTypes.ts
+++ b/src/pages/GamePage/types/ingameTypes.ts
@@ -1,1 +1,1 @@
-export type NumberIndexSignitureType = { [key: number]: number };
+export type NumberIndexSignatureType = { [key: number]: number };

--- a/src/pages/GamePage/types/ingameTypes.ts
+++ b/src/pages/GamePage/types/ingameTypes.ts
@@ -1,1 +1,1 @@
-export type CarImgType = { [key: number]: number };
+export type NumberIndexSignitureType = { [key: number]: number };

--- a/src/store/useCarStore.ts
+++ b/src/store/useCarStore.ts
@@ -1,9 +1,9 @@
 import { create } from 'zustand';
-import { CarImgType } from '@/pages/GamePage/types/ingameTypes';
+import { NumberIndexSignitureType } from '@/pages/GamePage/types/ingameTypes';
 
 interface I_useCarImgStore {
-  carImgStore: CarImgType;
-  setCarImgStore: (carImgStore: CarImgType) => void;
+  carImgStore: NumberIndexSignitureType;
+  setCarImgStore: (carImgStore: NumberIndexSignitureType) => void;
 }
 
 const useCarImgStore = create<I_useCarImgStore>((set) => ({

--- a/src/store/useCarStore.ts
+++ b/src/store/useCarStore.ts
@@ -1,9 +1,9 @@
 import { create } from 'zustand';
-import { NumberIndexSignitureType } from '@/pages/GamePage/types/ingameTypes';
+import { NumberIndexSignatureType } from '@/pages/GamePage/types/ingameTypes';
 
 interface I_useCarImgStore {
-  carImgStore: NumberIndexSignitureType;
-  setCarImgStore: (carImgStore: NumberIndexSignitureType) => void;
+  carImgStore: NumberIndexSignatureType;
+  setCarImgStore: (carImgStore: NumberIndexSignatureType) => void;
 }
 
 const useCarImgStore = create<I_useCarImgStore>((set) => ({


### PR DESCRIPTION
## 📋 Issue Number
close #243 #266 

## 💻 구현 내용

- 유저 이탈시 자동차트랙상위치(y좌표)를 유지합니다
  -> 게임 시작시의 유저 목록을 가져서 인덱스로 사용했습니다 
- 100점이후에도 그 전처럼 트랙을 계속해서 이동합니다. (화면에서 사라지던 이슈 해결)


(흐름 요약)
인게임 시작할때 초기 유저 전체를 저장 `originUsers`
{유저아이디 : 점수} 쌍의 `idScore` 저장 ->(변하지않은 차 다시 그리지 않기 위함인데 추후 수정 예정
프롭스로 넘어오는 응답값인 allMembers를 돌면서 carsRef[memberId] 에 좌표 계산
좌표로 자동차 그림

## 📷 Screenshots


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->

나간 유저의 차를 그리지 않기 위해 EXIT를 감지해서 allMembers에서 해당 유저를 지웠었는데,, 트랙상 좌표 유지를 고민하다 보니 나간 멤버도 있으면 더 편했겠다는 생각이 들었네요.... @_@

타입이랑 코드가 정리가 많이 안되어있는데,, 코드 정리와 최적화를 고민하여 리팩토링하겠습니다._빠른시일내로.._

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
