### PR TITLE
[Fix]: 브라우저 뒤로가기로 나간후 방 입장, 생성 이슈 해결

### DIFF
--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -3,6 +3,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
 import { useAuthCheck } from '@/hooks/useAuth/useAuth';
 import useOnlineUsers from '@/hooks/useOnlineUsers';
+import useGameWaitingRoomStore from '@/store/useGameWaitingRoomStore';
 import useRoomInfoStore from '@/store/useRoomInfoStore';
 import { GameModeType } from '@/types/gameMode';
 import CreateRoomModal from './CreateRoom/CreateRoomModal';
@@ -34,12 +35,14 @@ const MainPage = () => {
   const { data: userList } = useOnlineUsers();
   const { data: userData, isPending, error } = useAuthCheck();
   const { roomInfo, setRoomInfo } = useRoomInfoStore();
-
   const [selectedGameMode, setSelectedGameMode] =
     useState<FilteredGameModeType>('ALL');
-
+  const { setDidAdminStart } = useGameWaitingRoomStore();
   useEffect(() => {
-    roomInfo && setRoomInfo(null);
+    setDidAdminStart(false);
+    if (roomInfo) {
+      setRoomInfo(null);
+    }
   }, []);
   if (isPending) {
     return <div>유저 정보 불러오는중...</div>;


### PR DESCRIPTION
## 📋 Issue Number
close #261 

## 💻 구현 내용

- 게임페이지에서 didAdminStart를 초기화합니다.
브라우저 뒤로가기로 main으로 온 상황에 didAdminStart가 계속 true인게 문제였습니다.🫠

## 📷 Screenshots


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
