### PR TITLE
[Fix] 동점자 순위, 문장당5초, 인게임랭킹 스타일수정

### DIFF
--- a/src/pages/GamePage/GameCode/GameCode.tsx
+++ b/src/pages/GamePage/GameCode/GameCode.tsx
@@ -4,6 +4,7 @@ import IngameRank from '@/common/Ingame/IngameRank';
 import useIngameStore from '@/store/useIngameStore';
 import CanvasTrack from '../common/CanvasTrack';
 import TrackLine from '../common/TrackLine';
+import { SECONDS_PER_SENTENCE } from '../constants';
 import useTypingState from '../GameSentence/useTypingState';
 import useGameRound from '../hooks/useGameRound';
 import { I_Question, PublishIngameType } from '../types/websocketType';
@@ -13,8 +14,6 @@ interface GameCodeProps {
   publishIngame: PublishIngameType;
   userId: number;
 }
-
-const SECONDS_PER_SENTENCE = 7;
 
 const GameCode = ({ publishIngame, userId }: GameCodeProps) => {
   const { ingameRoomRes } = useIngameStore();

--- a/src/pages/GamePage/GameFinish/GameFinish.tsx
+++ b/src/pages/GamePage/GameFinish/GameFinish.tsx
@@ -43,8 +43,8 @@ const GameFinish = ({
       .sort(
         ({ score: prevScore }, { score: nextScore }) => nextScore - prevScore
       )
-      .map((data, idx) => {
-        if (idx !== 0 && data.score !== allMembers[idx - 1].score) {
+      .map((data, idx, sortedData) => {
+        if (idx !== 0 && data.score !== sortedData[idx - 1].score) {
           rank = idx + 1;
         }
         return { ...data, ranking: rank };

--- a/src/pages/GamePage/GameFinish/GameFinish.tsx
+++ b/src/pages/GamePage/GameFinish/GameFinish.tsx
@@ -58,7 +58,7 @@ const GameFinish = ({
         </span>
       </section>
       <section className='flex gap-[10rem] w-full'>
-        <div className='flex flex-grow justify-center'>
+        <div className='flex grow justify-center'>
           <RankList convertedRankData={convertedRankData} />
         </div>
       </section>

--- a/src/pages/GamePage/GameFinish/GameFinish.tsx
+++ b/src/pages/GamePage/GameFinish/GameFinish.tsx
@@ -58,37 +58,7 @@ const GameFinish = ({
         </span>
       </section>
       <section className='flex gap-[10rem] w-full'>
-        <div className='flex flex-1 justify-center items-end'>
-          <div
-            className='h-[28rem] w-[14rem] flex items-center justify-center shadow-2xl text-[5rem] font-bold'
-            style={{
-              backgroundImage:
-                'linear-gradient(0deg, #8B8C8D 0%, #C0C0C0 25%, #6D6E71 50%, #F5F5F5 100%)',
-              boxShadow: '0 3px 10px rgba(0, 0, 0, 0.2)',
-            }}>
-            2
-          </div>
-          <div
-            className='h-[40rem] w-[14rem] flex items-center justify-center shadow-2xl text-[5rem] font-bold'
-            style={{
-              backgroundImage:
-                'linear-gradient(0deg, #ECC440 0%, #FFFA8A 25%, #DDAC17 50%, #FFFF95 100%)',
-              boxShadow: '0 3px 10px rgba(0, 0, 0, 0.2)',
-            }}>
-            1
-          </div>
-          <div
-            className='h-[20rem] w-[14rem] flex items-center justify-center shadow-2xl text-[5rem] font-bold'
-            style={{
-              backgroundImage:
-                'linear-gradient(0deg, #CD7F32 0%, #E89752 25%, #8B4513 50%, #CD7F32 100%)',
-              boxShadow: '0 3px 10px rgba(0, 0, 0, 0.2)',
-            }}>
-            3
-          </div>
-        </div>
-
-        <div className='flex-1'>
+        <div className='flex flex-grow justify-center'>
           <RankList convertedRankData={convertedRankData} />
         </div>
       </section>

--- a/src/pages/GamePage/GameFinish/sortScore.test.ts
+++ b/src/pages/GamePage/GameFinish/sortScore.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from 'vitest';
+import { sortedRank, sortedRankTie } from './sortScore';
+
+const members = [
+  {
+    nickname: '에지니22',
+    score: 237,
+  },
+  {
+    nickname: '손님624c1',
+    score: 129,
+  },
+  {
+    nickname: '종욱',
+    score: 237,
+  },
+  {
+    nickname: 'ddd',
+    score: 99,
+  },
+];
+const sortedTieResult = [
+  {
+    nickname: '에지니22',
+    score: 237,
+    ranking: 1,
+  },
+  {
+    nickname: '종욱',
+    score: 237,
+    ranking: 1,
+  },
+  {
+    nickname: '손님624c1',
+    score: 129,
+    ranking: 3,
+  },
+  {
+    nickname: 'ddd',
+    score: 99,
+    ranking: 4,
+  },
+];
+const sortedResult = [
+  {
+    nickname: '에지니22',
+    score: 237,
+  },
+  {
+    nickname: '종욱',
+    score: 237,
+  },
+  {
+    nickname: '손님624c1',
+    score: 129,
+  },
+  {
+    nickname: 'ddd',
+    score: 99,
+  },
+];
+test('공동 등수', () => {
+  expect(sortedRankTie({ members })).toEqual(sortedTieResult);
+});
+test('등수', () => {
+  expect(sortedRank({ members })).toEqual(sortedResult);
+});

--- a/src/pages/GamePage/GameFinish/sortScore.ts
+++ b/src/pages/GamePage/GameFinish/sortScore.ts
@@ -1,0 +1,30 @@
+interface I_member {
+  nickname: string;
+  score: number;
+}
+export const sortedRankTie = ({ members }: { members: I_member[] }) => {
+  let rank = 1;
+  return members
+    .map(({ nickname, score }) => ({
+      nickname,
+      score,
+    }))
+    .sort(({ score: prevScore }, { score: nextScore }) => nextScore - prevScore)
+    .map((data, idx, arr) => {
+      if (idx !== 0 && data.score !== arr[idx - 1].score) {
+        rank = idx + 1;
+      }
+      return { ...data, ranking: rank };
+    });
+};
+
+export const sortedRank = ({ members }: { members: I_member[] }) => {
+  return members
+    .map(({ nickname, score }) => ({
+      nickname,
+      score,
+    }))
+    .sort(
+      ({ score: prevScore }, { score: nextScore }) => nextScore - prevScore
+    );
+};

--- a/src/pages/GamePage/GameSentence/GameSentence.tsx
+++ b/src/pages/GamePage/GameSentence/GameSentence.tsx
@@ -6,6 +6,7 @@ import { SentenceNext } from '@/common/Ingame/SentenceBlocks';
 import useIngameStore from '@/store/useIngameStore';
 import CanvasTrack from '../common/CanvasTrack';
 import TrackLine from '../common/TrackLine';
+import { SECONDS_PER_SENTENCE } from '../constants';
 import useGameRound from '../hooks/useGameRound';
 import { I_Question, PublishIngameType } from '../types/websocketType';
 import GameForm from './GameForm';
@@ -14,8 +15,6 @@ interface GameSentenceProps {
   publishIngame: PublishIngameType;
   userId: number;
 }
-
-const SECONDS_PER_SENTENCE = 7;
 
 export type UpdateScoreType = () => void;
 

--- a/src/pages/GamePage/constants.ts
+++ b/src/pages/GamePage/constants.ts
@@ -3,3 +3,4 @@ export const GAME_TYPE = new Map([
   ['SENTENCE', '문장 게임'],
   ['CODE', '코드 게임'],
 ]);
+export const SECONDS_PER_SENTENCE = 5;

--- a/src/pages/RankPage/RankList.tsx
+++ b/src/pages/RankPage/RankList.tsx
@@ -15,7 +15,7 @@ const RankList = ({ convertedRankData }: RankListProps) => {
   }, [convertedRankData]);
 
   return (
-    <div className='flex flex-col rounded-2xl overflow-hidden'>
+    <div className='flex flex-col rounded-2xl overflow-hidden w-[100rem]'>
       <div className='flex gap-2 justify-center font-bold font-[Giants-Inline] text-5xl py-4 px-4 border-b border-gray-200'>
         <span className='flex-1 text-center'>순위</span>
         <span className='flex-1 text-center'>닉네임</span>


### PR DESCRIPTION
## 📋 Issue Number
close #286 

## 💻 구현 내용

- 공동 등수 산정 로직 수정
- 문장당 입력 시간 5초로 변경
- 인게임랭킹에서 시상대 삭제

## 📷 Screenshots
![스크린샷 2024-03-21 12 14 30](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/81412212/89c602cd-e541-4343-9e72-c3b3235f2a3d)


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분
, 모르는 점, 궁금한 점 -->

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
_마무리다보니,, 한브랜치에 작업을 한번에 하게되었습니다.._