### PR TITLE
[Style] 일관된 UI, UX 개선

### DIFF
--- a/src/pages/GamePage/GameFinish/GameFinish.tsx
+++ b/src/pages/GamePage/GameFinish/GameFinish.tsx
@@ -69,7 +69,7 @@ const GameFinish = ({
             navigate(0);
           }}
           className='bg-coral-100 px-6 py-6 rounded-[1rem] text-[2rem] font-bold'>
-          로비로 나가기
+          메인으로 나가기
         </button>
         <button
           onClick={() => {

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -73,7 +73,7 @@ const GamePage = () => {
 
     if (gameRoomRes?.type === 'MODIFIED') {
       gameRoomRes.roomInfo?.hostId !== userId &&
-        Toast.info('게임 정보가 수정되었습니다!');
+        Toast.info('게임 대기실의 설정이 변경되었습니다!');
     }
   }, [gameRoomRes]);
 

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -73,7 +73,7 @@ const GamePage = () => {
 
     if (gameRoomRes?.type === 'MODIFIED') {
       gameRoomRes.roomInfo?.hostId !== userId &&
-        Toast.info('게임 대기실의 설정이 변경되었습니다!');
+        Toast.info('게임 설정이 변경되었습니다!');
     }
   }, [gameRoomRes]);
 

--- a/src/pages/GamePage/GamePage.tsx
+++ b/src/pages/GamePage/GamePage.tsx
@@ -4,6 +4,7 @@ import Loading from '@/common/Loading/Loading';
 import { useAuthCheck } from '@/hooks/useAuth/useAuth';
 import useGameWaitingRoomStore from '@/store/useGameWaitingRoomStore';
 import useRoomInfoStore from '@/store/useRoomInfoStore';
+import { Toast } from '@/utils/toast';
 import GameWaitingRoom from './GameWaitingRoom/GameWaitingRoom';
 import useWebsocket from './hooks/useWebsocket';
 import IngameWebsocketLayer from './IngameWebsocketLayer';
@@ -59,15 +60,22 @@ const GamePage = () => {
   }, []);
 
   useEffect(() => {
-    if (gameRoomRes?.roomInfo) {
-      setRoomInfo(gameRoomRes.roomInfo);
-    }
-
     if (isKicked) {
       navigate('/main', { replace: true });
       navigate(0);
     }
-  }, [gameRoomRes, isKicked]);
+  }, [isKicked]);
+
+  useEffect(() => {
+    if (gameRoomRes?.roomInfo) {
+      setRoomInfo(gameRoomRes.roomInfo);
+    }
+
+    if (gameRoomRes?.type === 'MODIFIED') {
+      gameRoomRes.roomInfo?.hostId !== userId &&
+        Toast.info('게임 정보가 수정되었습니다!');
+    }
+  }, [gameRoomRes]);
 
   if (!roomId || isWsError) {
     navigate('/main', { replace: true });

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -63,7 +63,7 @@ const MainPage = () => {
         <article
           className='flex items-center justify-center bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 h-[4.5rem] w-full cursor-pointer hover:bg-green-100 hover:text-white hover:text-[1.8rem] transition-all'
           onClick={() => navigate('/rank')}>
-          <button>전체 랭킹 페이지</button>
+          <button>전체 랭킹</button>
         </article>
         <UserCard
           nickname={userData.data.data!.nickname}

--- a/src/pages/RankPage/RankPage.tsx
+++ b/src/pages/RankPage/RankPage.tsx
@@ -11,9 +11,9 @@ const RankPage = () => {
 
   const tabData = [
     { value: '', text: '전체' },
-    { value: 'WORD', text: '단어' },
     { value: 'SENTENCE', text: '문장' },
     { value: 'CODE', text: '코드' },
+    { value: 'WORD', text: '단어' },
   ];
 
   const navigate = useNavigate();


### PR DESCRIPTION
## 📋 Issue Number
close #

## 💻 구현 내용

- [x]  토스트로 일반 유저에게 '게임 대기실의 설정이 변경되었습니다!' 알림처리
- [x]  로비로 나가기 → 메인으로 나가기
- [x]  메인페이지에 있는 전체 랭킹 페이지 → 전체 랭킹
- [x]  랭킹 페이지 → 전체 , 문장, 코드, 단어 순으로 바꾸기

## 📷 Screenshots

https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/a63941b4-23d1-4867-954f-d7ef863c7a42



## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
