### PR TITLE
[Fix] 번들링 최적화 - code split

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,5 @@
   },
   "lint-staged": {
     "./src/**/*.{js,jsx,ts,tsx}": "eslint --cache --fix"
-  },
-  "packageManager": "yarn@4.1.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -75,5 +75,6 @@
   },
   "lint-staged": {
     "./src/**/*.{js,jsx,ts,tsx}": "eslint --cache --fix"
-  }
+  },
+  "packageManager": "yarn@4.1.0"
 }

--- a/src/common/Spinner/Spinner.tsx
+++ b/src/common/Spinner/Spinner.tsx
@@ -9,7 +9,7 @@ const Spinner = ({ wrapperClass, svgClass }: SpinnerProps) => {
   return (
     <div
       role='status'
-      className={wrapperClass}>
+      className={`absolute top-1/2 left-1/2 ${wrapperClass}`}>
       <svg
         aria-hidden='true'
         className={`size-[6rem] text-gray-100 animate-spin dark:text-gray-600 fill-green-500 ${svgClass}`}

--- a/src/common/Spinner/Spinner.tsx
+++ b/src/common/Spinner/Spinner.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 
-interface SpinnerProps extends React.SVGProps<SVGElement> {}
+interface SpinnerProps {
+  wrapperClass?: React.HTMLAttributes<HTMLDivElement>['className'];
+  svgClass?: React.SVGProps<SVGElement>['className'];
+}
 
-const Spinner = ({ className }: SpinnerProps) => {
+const Spinner = ({ wrapperClass, svgClass }: SpinnerProps) => {
   return (
-    <div role='status'>
+    <div
+      role='status'
+      className={wrapperClass}>
       <svg
         aria-hidden='true'
-        className={`size-[6rem] text-gray-100 animate-spin dark:text-gray-600 fill-green-500 ${className}`}
+        className={`size-[6rem] text-gray-100 animate-spin dark:text-gray-600 fill-green-500 ${svgClass}`}
         viewBox='0 0 100 101'
         fill='none'
         xmlns='http://www.w3.org/2000/svg'>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import ErrorBoundaryFallback from './common/Error/ErrorBoundaryFallback.tsx';
 import Header from './common/Header/Header.tsx';
 import BodyLayout from './common/Layout/BodyLayout.tsx';
 import Layout from './common/Layout/Layout.tsx';
+import Spinner from './common/Spinner/Spinner.tsx';
 import KaKaoLoginPage from './pages/KaKaoLoginPage/KaKaoLoginPage.tsx';
 import DefaultErrorFallback from './pages/MainPage/DefaultErrorFallback.tsx';
 import MainPage from './pages/MainPage/MainPage.tsx';
@@ -67,12 +68,16 @@ export const router = createBrowserRouter([
           },
           {
             path: '/game',
-            element: <GamePage />,
+            element: (
+              <Suspense fallback={<Spinner />}>
+                <GamePage />
+              </Suspense>
+            ),
           },
           {
             path: '/rank',
             element: (
-              <Suspense fallback={<div>Loading...</div>}>
+              <Suspense fallback={<Spinner />}>
                 <RankPage />
               </Suspense>
             ),

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,11 +14,11 @@ import DefaultErrorFallback from './pages/MainPage/DefaultErrorFallback.tsx';
 import MainPage from './pages/MainPage/MainPage.tsx';
 import NicknamePage from './pages/NicknamePage/NicknamePage.tsx';
 import NotFoundPage from './pages/NotFoundPage/NotFoundPage.tsx';
-import RankPage from './pages/RankPage/RankPage.tsx';
 import SettingPage from './pages/SettingPage/SettingPage.tsx';
 import StartPage from './pages/StartPage/StartPage.tsx';
 
 const GamePage = React.lazy(() => import('./pages/GamePage/GamePage.tsx'));
+const RankPage = React.lazy(() => import('./pages/RankPage/RankPage.tsx'));
 
 export const router = createBrowserRouter([
   {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 import './index.css';
-import { Suspense } from 'react';
+import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom/client';
 import { ErrorBoundary } from 'react-error-boundary';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
@@ -9,7 +9,6 @@ import ErrorBoundaryFallback from './common/Error/ErrorBoundaryFallback.tsx';
 import Header from './common/Header/Header.tsx';
 import BodyLayout from './common/Layout/BodyLayout.tsx';
 import Layout from './common/Layout/Layout.tsx';
-import GamePage from './pages/GamePage/GamePage.tsx';
 import KaKaoLoginPage from './pages/KaKaoLoginPage/KaKaoLoginPage.tsx';
 import DefaultErrorFallback from './pages/MainPage/DefaultErrorFallback.tsx';
 import MainPage from './pages/MainPage/MainPage.tsx';
@@ -18,6 +17,8 @@ import NotFoundPage from './pages/NotFoundPage/NotFoundPage.tsx';
 import RankPage from './pages/RankPage/RankPage.tsx';
 import SettingPage from './pages/SettingPage/SettingPage.tsx';
 import StartPage from './pages/StartPage/StartPage.tsx';
+
+const GamePage = React.lazy(() => import('./pages/GamePage/GamePage.tsx'));
 
 export const router = createBrowserRouter([
   {

--- a/src/pages/GamePage/IngameWebsocketLayer.tsx
+++ b/src/pages/GamePage/IngameWebsocketLayer.tsx
@@ -64,30 +64,26 @@ const IngameWebsocketLayer = ({
         isOpen={isRoundWaiting}
         onTimeFinish={() => setIsRoundWaiting(false)}
       />
-      {roomInfo?.gameMode === 'SENTENCE' && (
-        <Suspense fallback={<Spinner />}>
+      <Suspense>
+        {roomInfo?.gameMode === 'SENTENCE' && (
           <GameSentence
             publishIngame={publishIngame}
             userId={userId}
           />
-        </Suspense>
-      )}
-      {roomInfo?.gameMode === 'CODE' && (
-        <Suspense fallback={<Spinner />}>
+        )}
+        {roomInfo?.gameMode === 'CODE' && (
           <GameCode
             publishIngame={publishIngame}
             userId={userId}
           />
-        </Suspense>
-      )}
-      {roomInfo?.gameMode === 'WORD' && (
-        <Suspense fallback={<Spinner />}>
+        )}
+        {roomInfo?.gameMode === 'WORD' && (
           <GameWord
             publishIngame={publishIngame}
             userId={userId}
           />
-        </Suspense>
-      )}
+        )}
+      </Suspense>
     </>
   );
 };

--- a/src/pages/GamePage/IngameWebsocketLayer.tsx
+++ b/src/pages/GamePage/IngameWebsocketLayer.tsx
@@ -64,7 +64,7 @@ const IngameWebsocketLayer = ({
         isOpen={isRoundWaiting}
         onTimeFinish={() => setIsRoundWaiting(false)}
       />
-      <Suspense>
+      <Suspense fallback={<Spinner />}>
         {roomInfo?.gameMode === 'SENTENCE' && (
           <GameSentence
             publishIngame={publishIngame}

--- a/src/pages/GamePage/IngameWebsocketLayer.tsx
+++ b/src/pages/GamePage/IngameWebsocketLayer.tsx
@@ -1,13 +1,10 @@
-import { useEffect } from 'react';
+import React, { Suspense, useEffect } from 'react';
+import Spinner from '@/common/Spinner/Spinner';
 import useIngameStore from '@/store/useIngameStore';
 import useRoomInfoStore from '@/store/useRoomInfoStore';
 import { checkIsEmptyObj } from '@/utils/checkIsEmptyObj';
 import RoundWaitModal from './common/RoundWaitModal';
 import WsError from './common/WsError';
-import GameCode from './GameCode/GameCode';
-import GameFinish from './GameFinish/GameFinish';
-import GameSentence from './GameSentence/GameSentence';
-import GameWord from './GameWord/GameWord';
 import { PublishIngameType } from './types/websocketType';
 
 interface IngameWebsocketLayerProps {
@@ -16,6 +13,12 @@ interface IngameWebsocketLayerProps {
   onIngameConnected: () => void;
   handleConnectIngame: (roomId: number) => void;
 }
+
+const GameCode = React.lazy(() => import('./GameCode/GameCode'));
+const GameFinish = React.lazy(() => import('./GameFinish/GameFinish'));
+const GameWord = React.lazy(() => import('./GameWord/GameWord'));
+const GameSentence = React.lazy(() => import('./GameSentence/GameSentence'));
+
 const IngameWebsocketLayer = ({
   userId,
   publishIngame,
@@ -46,10 +49,12 @@ const IngameWebsocketLayer = ({
 
   if (ingameRoomRes.type === 'FINISH') {
     return (
-      <GameFinish
-        allMembers={ingameRoomRes.allMembers}
-        userId={userId}
-      />
+      <Suspense fallback={<Spinner />}>
+        <GameFinish
+          allMembers={ingameRoomRes.allMembers}
+          userId={userId}
+        />
+      </Suspense>
     );
   }
 
@@ -60,22 +65,28 @@ const IngameWebsocketLayer = ({
         onTimeFinish={() => setIsRoundWaiting(false)}
       />
       {roomInfo?.gameMode === 'SENTENCE' && (
-        <GameSentence
-          publishIngame={publishIngame}
-          userId={userId}
-        />
+        <Suspense fallback={<Spinner />}>
+          <GameSentence
+            publishIngame={publishIngame}
+            userId={userId}
+          />
+        </Suspense>
       )}
       {roomInfo?.gameMode === 'CODE' && (
-        <GameCode
-          publishIngame={publishIngame}
-          userId={userId}
-        />
+        <Suspense fallback={<Spinner />}>
+          <GameCode
+            publishIngame={publishIngame}
+            userId={userId}
+          />
+        </Suspense>
       )}
       {roomInfo?.gameMode === 'WORD' && (
-        <GameWord
-          publishIngame={publishIngame}
-          userId={userId}
-        />
+        <Suspense fallback={<Spinner />}>
+          <GameWord
+            publishIngame={publishIngame}
+            userId={userId}
+          />
+        </Suspense>
       )}
     </>
   );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import mkcert from 'vite-plugin-mkcert';
-import fs from 'fs'
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), mkcert()],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,10 +2,26 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import mkcert from 'vite-plugin-mkcert';
+import fs from 'fs'
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react(), mkcert()],
+export default defineConfig(({command})=>{
+  return {plugins: [react(), mkcert(),{
+    name: 'build-script',
+        buildStart() {
+          if (command === 'build') {
+            const isDevelopment = process.env.NODE_ENV === 'development';
+            const packageManager = isDevelopment ? 'yarn@4.1.0' : undefined;
+
+            const packageJsonPath = './package.json';
+            const packageJson = require(packageJsonPath);
+
+            packageJson.packageManager = packageManager;
+
+            // 변경된 package.json 파일을 저장합니다.
+            fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+          }}
+  }],
   resolve: {
     alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
-  },
+  },}
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,11 @@
-import { defineConfig } from 'vite';
+import { defineConfig, splitVendorChunkPlugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import mkcert from 'vite-plugin-mkcert';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), mkcert()],
+  plugins: [react(), mkcert(), splitVendorChunkPlugin()],
   resolve: {
     alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
   }}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,24 +4,9 @@ import path from 'path';
 import mkcert from 'vite-plugin-mkcert';
 import fs from 'fs'
 // https://vitejs.dev/config/
-export default defineConfig(({command})=>{
-  return {plugins: [react(), mkcert(),{
-    name: 'build-script',
-        buildStart() {
-          if (command === 'build') {
-            const isDevelopment = process.env.NODE_ENV === 'development';
-            const packageManager = isDevelopment ? 'yarn@4.1.0' : undefined;
-
-            const packageJsonPath = './package.json';
-            const packageJson = require(packageJsonPath);
-
-            packageJson.packageManager = packageManager;
-
-            // 변경된 package.json 파일을 저장합니다.
-            fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
-          }}
-  }],
+export default defineConfig({
+  plugins: [react(), mkcert()],
   resolve: {
     alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
-  },}
-});
+  }}
+);


### PR DESCRIPTION
## 📋 Issue Number
close #290 

## 💻 구현 내용

- 번들링 최적화를 위하여 code splitting을 통해 청크사이즈를 줄였습니다.
- 첫 렌더링시 필요한 컴포넌트를 제외한 컴포넌트 중 사이즈가 큰 컴포넌트를 `React.lazy`를 사용하여 비동기 렌더링을 하였습니다.
- `React.lazy`로 불러오는 컴포넌트는 비동기렌더링이기에 `Suspense`로 감싸서 UX를 개선하였습니다
- Spinner컴포넌트의 props를 수정하였습니다. 또한 기본 스타일을 추가하였습니다(`absolute top-1/2 left-1/2`)
- 각 청크에서 공통으로 쓰이는 모듈을 `vendor`로 분리하였습니다.

## 📷 Screenshots

### before code splitting
![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/b3d7d8c7-5a56-4f3f-9e3a-361cd805b9b8)

### after code splitting
![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/fb3f71e4-bd63-4ec6-a643-0b7510c10609)

## 🤔 고민사항
각  게임 컴포넌트 내부에서 동적 import로 청크사이즈를 더 줄이려다가, 게임 컴포넌트가 렌더링될땐 내부 모듈을 한번에 불러와야 할 것 같아 줄이지 않았습니다. 맞는 판단일까용?