### PR TITLE
[Style] 방 목록 넘칠시 레이아웃 깨짐 수정 (긴...급...) 🚨 

### DIFF
--- a/src/pages/MainPage/GameRoomList.tsx
+++ b/src/pages/MainPage/GameRoomList.tsx
@@ -42,7 +42,7 @@ const GameRoomList = ({ data, selectedGameMode }: GameRoomListProps) => {
         </li>
         <Divider className='border-gray-200' />
         <li className='w-full'>
-          <ul className='w-full flex flex-col gap-[1.2rem] max-h-[60rem] overflow-y-auto scrollbar-hide py-[1rem]'>
+          <ul className='w-full flex flex-col gap-[1.2rem] max-h-[50rem] overflow-y-auto py-[1rem]'>
             {filteredRoomList.map((roomData) => (
               <Fragment key={roomData.id}>
                 <GameRoomListItem


### PR DESCRIPTION
## 📋 Issue Number
close #x

## 💻 구현 내용

- 방 목록 넘칠시 레이아웃 깨짐을 수정하였습니다
- 임시로 스크롤 바를 부착하였습니다(영재님의 의견 반영)

## 📷 Screenshots

![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/55bb84ed-f7f3-41a1-aec0-4b85381ed602)
