### PR TITLE
[Style] 랭킹 스크롤 넘칠시 레이아웃 깨짐 수정 (긴...급...) 🚨2

### DIFF
--- a/src/pages/RankPage/RankList.tsx
+++ b/src/pages/RankPage/RankList.tsx
@@ -15,19 +15,21 @@ const RankList = ({ convertedRankData }: RankListProps) => {
   }, [convertedRankData]);
 
   return (
-    <div className='flex flex-col rounded-2xl overflow-hidden w-[100rem]'>
+    <div className='flex flex-col rounded-2xl w-[80rem] max-h-[50rem] '>
       <div className='flex gap-2 justify-center font-bold font-[Giants-Inline] text-5xl py-4 px-4 border-b border-gray-200'>
         <span className='flex-1 text-center'>순위</span>
         <span className='flex-1 text-center'>닉네임</span>
         <span className='flex-1 text-center'>점수</span>
       </div>
-      {sortedConvertedRankData.map((rank, index) => (
-        <RankItem
-          key={index}
-          rank={rank}
-          index={index}
-        />
-      ))}
+      <div className='overflow-y-auto'>
+        {sortedConvertedRankData.map((rank, index) => (
+          <RankItem
+            key={index}
+            rank={rank}
+            index={index}
+          />
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 📋 Issue Number
close #

## 💻 구현 내용

- 유저가 많아져서 랭킹이 화면 넘어감에 스크롤 처리했습니다

## 📷 Screenshots
<img width="1582" alt="스크린샷 2024-03-23 21 38 35" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/81412212/6ee328a7-a4e3-4f9b-93e1-7fa470f6d931">
<img width="1582" alt="스크린샷 2024-03-23 21 50 03" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/81412212/c88aafab-c919-48d8-83b8-aac34f84e740">


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
