### PR TITLE
[Style] 게임중인 방 목록 UI 추가

### DIFF
--- a/src/hooks/useEnterGameRoom.ts
+++ b/src/hooks/useEnterGameRoom.ts
@@ -1,8 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
-import { useNavigate } from 'react-router-dom';
 import { enterGameRoom } from '@/apis/api';
 import { ApiResponseGameRoomEnterResponse, ErrorResponse } from '@/generated';
+import { Toast } from '@/utils/toast';
 
 interface UseEnterGameRoomProps {
   onSuccess?: (e: AxiosResponse<ApiResponseGameRoomEnterResponse>) => void;
@@ -15,7 +15,6 @@ export interface I_UseEnterGameRoomMutation {
 }
 
 const useEnterGameRoom = ({ onSuccess, onError }: UseEnterGameRoomProps) => {
-  const navigate = useNavigate();
   return useMutation<
     AxiosResponse<ApiResponseGameRoomEnterResponse>,
     Error | AxiosError<ErrorResponse>,
@@ -29,8 +28,7 @@ const useEnterGameRoom = ({ onSuccess, onError }: UseEnterGameRoomProps) => {
     },
     onError: (e) => {
       if (e instanceof AxiosError) {
-        alert(e.response?.data.errorMessage);
-        navigate(0);
+        Toast.info(`${e.response?.data.errorMessage}`);
         onError?.(e);
       }
     },

--- a/src/pages/MainPage/GameRoomList.tsx
+++ b/src/pages/MainPage/GameRoomList.tsx
@@ -15,11 +15,10 @@ interface GameRoomListProps extends React.HTMLAttributes<HTMLDivElement> {
 const GameRoomList = ({ data, selectedGameMode }: GameRoomListProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const waitingRoomList = data.filter(({ isPlaying }) => !isPlaying);
   const filteredRoomList =
     selectedGameMode !== 'ALL'
-      ? waitingRoomList.filter(({ gameMode }) => gameMode === selectedGameMode)
-      : waitingRoomList;
+      ? data.filter(({ gameMode }) => gameMode === selectedGameMode)
+      : data;
 
   return (
     <article className='bg-white rounded-[0.5rem] border-solid border-[0.3rem] border-green-100 row-start-2 col-start-1 col-span-2'>

--- a/src/pages/MainPage/GameRoonListItem.tsx
+++ b/src/pages/MainPage/GameRoonListItem.tsx
@@ -58,7 +58,7 @@ const GameRoomListItem = ({
             {title}
           </span>
           <span
-            className={`text-white font-semibold rounded-[0.5rem] px-[0.4rem] ${isPlaying ? 'bg-red-500' : 'bg-green-100'}`}>
+            className={`text-white font-semibold rounded-[0.5rem] px-[0.4rem] ${isPlaying ? 'bg-red-500' : 'bg-green-500'}`}>
             {isPlaying ? '게임 중' : '대기 중'}
           </span>
         </div>

--- a/src/pages/MainPage/GameRoonListItem.tsx
+++ b/src/pages/MainPage/GameRoonListItem.tsx
@@ -45,9 +45,8 @@ const GameRoomListItem = ({
             ? () => setIsOpen(true)
             : () => mutateEnterGameRoom({ roomId: id })
         }
-        className={`${isPlaying ? 'opacity-50 cursor-not-allowed' : 'opacity-100 cursor-pointer'} h-[5rem] flex items-center shrink-0 w-full py-[1rem] bg-gray-10 
-      [clip-path:polygon(97%_0%,100%_50%,97%_100%,0%_100%,0%_0%)]
-      hover:bg-myGradient hover:animate-gameRoomList`}>
+        className={`${isPlaying ? 'opacity-50 cursor-not-allowed' : 'opacity-100 cursor-pointer hover:bg-myGradient hover:animate-gameRoomList'} 
+        h-[5rem] flex items-center shrink-0 w-full py-[1rem] bg-gray-10 [clip-path:polygon(97%_0%,100%_50%,97%_100%,0%_100%,0%_0%)]`}>
         <span className='text-center truncate flex-1'>{`No.${id}`}</span>
         <Divider
           orientation='vertical'

--- a/src/pages/MainPage/GameRoonListItem.tsx
+++ b/src/pages/MainPage/GameRoonListItem.tsx
@@ -23,6 +23,7 @@ const GameRoomListItem = ({
   maxPlayer,
   currentPlayer,
   isPrivate,
+  isPlaying,
   setIsOpen,
 }: GameRoomListItemProps) => {
   const { setRoomId } = useRoomInfoStore();
@@ -44,18 +45,22 @@ const GameRoomListItem = ({
             ? () => setIsOpen(true)
             : () => mutateEnterGameRoom({ roomId: id })
         }
-        className='h-[5rem] flex items-center shrink-0 w-full py-[1rem] bg-gray-10 cursor-pointer
+        className={`${isPlaying ? 'opacity-50 cursor-not-allowed' : 'opacity-100 cursor-pointer'} h-[5rem] flex items-center shrink-0 w-full py-[1rem] bg-gray-10 
       [clip-path:polygon(97%_0%,100%_50%,97%_100%,0%_100%,0%_0%)]
-      hover:bg-myGradient hover:animate-gameRoomList'>
+      hover:bg-myGradient hover:animate-gameRoomList`}>
         <span className='text-center truncate flex-1'>{`No.${id}`}</span>
         <Divider
           orientation='vertical'
           className='border-gray-200'
         />
-        <div className='flex-[4_0_0] truncate flex justify-center'>
+        <div className='flex-[4_0_0] truncate flex justify-center items-center'>
           {isPrivate && <LockClosedIcon className='size-[2rem]' />}
           <span className='text-center truncate max-w-[60%] px-[1rem]'>
             {title}
+          </span>
+          <span
+            className={`text-white font-semibold rounded-[0.5rem] px-[0.4rem] ${isPlaying ? 'bg-red-500' : 'bg-green-100'}`}>
+            {isPlaying ? '게임 중' : '대기 중'}
           </span>
         </div>
         <Divider


### PR DESCRIPTION
## 📋 Issue Number
close #x

## 💻 구현 내용

- 게임중인 방 목록 노출하게 수정하였습니다.
- 게임중인 방, 대기중인 방을 구분하는 UI를 추가하였습니다.
- 방 입장 후 에러메시지 반환시 Toast로 출력하게 변경하였습니다.

## 📷 Screenshots

### 게임중인 방(우측 하단 Toast 게임중 방 클릭시)
![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/db6d4809-00de-430c-a7dc-6e7c74f86f65)

### 대기중인 방(배경색 수정)
![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/0e70c7e2-caa5-49a0-a16a-e6d41bf03f5d)

![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/0d36e911-29ff-4058-92d0-903068e33c90)


## 🤔 고민사항

maxRound도 보이게 추가하면 좋을까요?