### PR TITLE
[Refactor]: useFocusInput 다른 input에서도 쓸 수 있도록 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,6 @@
   },
   "lint-staged": {
     "./src/**/*.{js,jsx,ts,tsx}": "eslint --cache --fix"
-  }
+  },
+  "packageManager": "yarn@4.1.0"
 }

--- a/src/pages/GamePage/GameCode/CodeForm.tsx
+++ b/src/pages/GamePage/GameCode/CodeForm.tsx
@@ -18,6 +18,7 @@ interface CodeFormProps {
   handleUpdateProblem: () => void;
   handleRoundFinish: () => void;
   handleUpdateCodeItem: () => void;
+  isRoundWaiting: boolean;
 }
 
 const CHAR_STATE = {
@@ -38,13 +39,14 @@ const CodeForm = ({
   handleUpdateProblem,
   handleRoundFinish,
   handleUpdateCodeItem,
+  isRoundWaiting,
 }: CodeFormProps) => {
   const { register, handleSubmit, setValue, getValues } = useForm<{
     ['code']: string;
   }>();
   const { ref } = register('code');
 
-  const { focusInput } = useFocusInput();
+  const { focusInput } = useFocusInput(isRoundWaiting);
 
   const currentPublishIndex = useRef(0);
 

--- a/src/pages/GamePage/GameCode/CodeFormContainer.tsx
+++ b/src/pages/GamePage/GameCode/CodeFormContainer.tsx
@@ -18,6 +18,7 @@ interface CodeFormContainerProps {
   ) => void;
   onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
   initializeTyping: () => void;
+  isRoundWaiting: boolean;
 }
 
 const CodeFormContainer = ({
@@ -31,6 +32,7 @@ const CodeFormContainer = ({
   onInputChange,
   onKeyDown,
   initializeTyping,
+  isRoundWaiting,
 }: CodeFormContainerProps) => {
   const [currentProblemIndex, setCurrentProblemIndex] = useState(0);
   const [currentCodeItemIndex, setCurrentCodeItemIndex] = useState(0);
@@ -68,6 +70,7 @@ const CodeFormContainer = ({
         handleUpdateProblem={handleUpdateProblem}
         handleRoundFinish={handleRoundFinish}
         handleUpdateCodeItem={handleUpdateCodeItem}
+        isRoundWaiting={isRoundWaiting}
       />
     </div>
   );

--- a/src/pages/GamePage/GameCode/GameCode.tsx
+++ b/src/pages/GamePage/GameCode/GameCode.tsx
@@ -16,7 +16,7 @@ interface GameCodeProps {
 }
 
 const GameCode = ({ publishIngame, userId }: GameCodeProps) => {
-  const { ingameRoomRes } = useIngameStore();
+  const { ingameRoomRes, isRoundWaiting } = useIngameStore();
   const codeList = useRef<I_Question[]>(ingameRoomRes.questions!);
 
   const convertedCodeList = codeList.current.map(({ question }) =>
@@ -121,7 +121,8 @@ const GameCode = ({ publishIngame, userId }: GameCodeProps) => {
             accurate={accurate}
             onInputChange={onInputChange}
             onKeyDown={onKeyDown}
-            initializeTyping={initializeTyping}>
+            initializeTyping={initializeTyping}
+            isRoundWaiting={isRoundWaiting}>
             <CodeContainer codeItem={codeList.current[0].question} />
           </CodeFormContainer>
         </div>

--- a/src/pages/GamePage/GameSentence/GameForm.tsx
+++ b/src/pages/GamePage/GameSentence/GameForm.tsx
@@ -17,6 +17,7 @@ interface GameFormProps {
   handleLineEnd: () => void;
   handleRoundFinish: () => void;
   isLastSentence: boolean;
+  isRoundWaiting: boolean;
 }
 
 type TypoMarkListType = '' | 'typo' | 'correct';
@@ -29,6 +30,7 @@ const GameForm = ({
   handleUpdateScore,
   handleRoundFinish,
   isLastSentence,
+  isRoundWaiting,
 }: GameFormProps) => {
   const {
     register,
@@ -43,7 +45,7 @@ const GameForm = ({
 
   const { ref } = register('sentence');
 
-  const { focusInput } = useFocusInput();
+  const { focusInput } = useFocusInput(isRoundWaiting);
 
   const [typoMarkList, setTypoMarkList] = useState<TypoMarkListType[]>(
     Array(sample.length).fill('')

--- a/src/pages/GamePage/GameSentence/GameSentence.tsx
+++ b/src/pages/GamePage/GameSentence/GameSentence.tsx
@@ -26,7 +26,7 @@ export interface I_RankInfoList {
 }
 
 const GameSentence = ({ publishIngame, userId }: GameSentenceProps) => {
-  const { ingameRoomRes } = useIngameStore();
+  const { ingameRoomRes, isRoundWaiting } = useIngameStore();
 
   const currentScore = ingameRoomRes.allMembers.find(
     ({ memberId }) => memberId === userId
@@ -123,6 +123,7 @@ const GameSentence = ({ publishIngame, userId }: GameSentenceProps) => {
               }}
               isLastSentence={sentenceList.current.length - 1 === sentenceIdx}
               handleRoundFinish={handleRoundFinish}
+              isRoundWaiting={isRoundWaiting}
             />
             <SentenceNext
               text={sentenceList.current[sentenceIdx + 1]?.question ?? ''}

--- a/src/pages/GamePage/GameWord/GameWord.tsx
+++ b/src/pages/GamePage/GameWord/GameWord.tsx
@@ -15,7 +15,7 @@ interface GameWordProps {
 const SECONDS_FOR_ALL_WORDS = 120;
 
 const GameWord = ({ publishIngame, userId }: GameWordProps) => {
-  const { ingameRoomRes } = useIngameStore();
+  const { ingameRoomRes, isRoundWaiting } = useIngameStore();
   const {
     cpm,
     averageCpm,
@@ -62,6 +62,7 @@ const GameWord = ({ publishIngame, userId }: GameWordProps) => {
               initializeTyping={initializeTyping}
               cpm={cpm}
               setAverageAccurate={setAverageAccurate}
+              isRoundWaiting={isRoundWaiting}
             />
           )}
         </div>

--- a/src/pages/GamePage/GameWord/WordGameLayout.tsx
+++ b/src/pages/GamePage/GameWord/WordGameLayout.tsx
@@ -22,6 +22,7 @@ interface GameWordProps {
   initializeTyping: () => void;
   cpm: number;
   setAverageAccurate: React.Dispatch<React.SetStateAction<number>>;
+  isRoundWaiting: boolean;
 }
 
 const WordGameLayout = ({
@@ -33,6 +34,7 @@ const WordGameLayout = ({
   initializeTyping,
   cpm,
   setAverageAccurate,
+  isRoundWaiting,
 }: GameWordProps) => {
   const { register, handleSubmit, setValue, getValues } = useForm<{
     ['wordInput']: string;
@@ -40,7 +42,7 @@ const WordGameLayout = ({
 
   const { ref } = register('wordInput');
 
-  const { focusInput } = useFocusInput();
+  const { focusInput } = useFocusInput(isRoundWaiting);
 
   const submitCount = useRef(0);
   const currentScore =

--- a/src/pages/GamePage/hooks/useFocusInput.ts
+++ b/src/pages/GamePage/hooks/useFocusInput.ts
@@ -1,20 +1,17 @@
 import { useEffect, useRef } from 'react';
-import useIngameStore from '@/store/useIngameStore';
 
-const useFocusInput = () => {
+const useFocusInput = (isFocus: boolean) => {
   const focusInput = useRef<HTMLInputElement | null>(null);
 
-  const { isRoundWaiting } = useIngameStore();
-
   useEffect(() => {
-    if (isRoundWaiting || !focusInput.current) {
+    if (isFocus || !focusInput.current) {
       return;
     }
     focusInput.current.focus();
     return () => {
       focusInput.current = null;
     };
-  }, [isRoundWaiting]);
+  }, [isFocus]);
 
   return { focusInput };
 };


### PR DESCRIPTION
## 📋 Issue Number
close #302 

## 💻 구현 내용

- useFocusInput 훅에 인자로 조건 값(isFocus)을 넘겨서 다른 input에서도 쓸 수 있게 만들었습니다.
   - 문장, 코드, 단어 게임에서 input에 focus 하기 위한 조건 값 : isRoundWaiting 

## 📷 Screenshots


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
- 다른 div나 button 엘리먼트 등에서도 사용할 수 있게 만들어보려고 했는데 타입 문제 때문에 실패했습니다.
- [참고한 자료](https://velog.io/@apparatus1/Typescript-useRef-%EC%9D%BD%EA%B8%B0-%EC%A0%84%EC%9A%A9-%EC%97%90%EB%9F%AC)
### 👀 문제점
#### 1. 현재 상황
<img width="702" alt="스크린샷 2024-03-28 오후 11 55 27" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/ac0ca46f-2fc7-4081-a1fa-250ebceab4c9">

- type이 mutableRef 여야함 (focusElement.current에 값을 넣기 위해서)
- <img width="228" alt="스크린샷 2024-03-29 오전 12 03 19" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/da2b69f4-f3c6-4540-951a-6b5365c59063">

#### 2. 겪고 있는 문제
- button 이나 div 엘리먼트는 type이 LegacyRef라 mutableRef를 할당할 수 없음
<img width="599" alt="스크린샷 2024-03-29 오전 12 19 42" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/5ee74b07-e80a-44cf-985a-7056c08d50f5">

#### 3. 해결 방안
??????

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
