### PR TITLE
[Feat] CI용 git actions 추가

### DIFF
--- a/.github/workflows/buildTest.yaml
+++ b/.github/workflows/buildTest.yaml
@@ -1,0 +1,35 @@
+name: Test of pull request main from other branch
+
+on:
+  pull_request:
+    branches: main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set Yarn Version
+        run: |
+          yarn set version 4.1.0
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build with yarn
+        run: yarn run build
+        env:
+          VITE_CLIENT_SECRET: ${{ secrets.VITE_CLIENT_SECRET }}
+          VITE_KAKAO_CLIENT_ID: ${{ secrets.VITE_KAKAO_CLIENT_ID }}
+          VITE_KAKAO_REDIRECT_URI: ${{ secrets.VITE_KAKAO_REDIRECT_URI }}

--- a/.github/workflows/buildTest.yaml
+++ b/.github/workflows/buildTest.yaml
@@ -5,7 +5,7 @@ on:
     branches: main
 
 jobs:
-  build-and-deploy:
+  Test-pull-request:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/buildTest.yaml
+++ b/.github/workflows/buildTest.yaml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Test utility functions
+        run: yarn run test
+
       - name: Build with yarn
         run: yarn run build
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,8 +3,6 @@ name: Tikitaza frontend continuous developments
 on:
   push:
     branches: main
-  pull_request:
-    branches: main
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -53,4 +53,4 @@ jobs:
       - name: CloudFront Invalidation
         env:
           CLOUD_FRONT_ID: ${{ secrets.AWS_CLOUDFRONT_ID }}
-        run: aws cloudfront create-invalidation --distribution-id $CLOUD_FRONT_ID --paths /*
+        run: aws cloudfront create-invalidation --distribution-id $CLOUD_FRONT_ID --paths "/*"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Node with Corepack
+      - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,17 +12,22 @@ jobs:
 
     steps:
       - name: Checkout
-      - uses: actions/checkout@v4
+        uses: actions/checkout@v4
 
-      - name: Set up Node
+      - name: Set up Node with Corepack
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: yarn
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Set Yarn Version
         run: |
           yarn set version 4.1.0
+
+      - name: Install dependencies
+        run: yarn install
 
       - name: Build with yarn
         run: yarn run build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-
+yarn lint-staged


### PR DESCRIPTION
## 📋 Issue Number
close #312 

## 💻 구현 내용

- `main`브랜치에 **push**시 자동배포하는 git actions를 추가하였습니다. 세부단계는 아래와 같습니다.
1. 브랜치를 복제합니다(checkout)
2. Node v20을 설치합니다
3. yarn v4를 사용하기위하여 corepack을 enable상태로 변경합니다
4. yarn 버전을 현재 저희 개발환경에서 사용중인 4.1.0으로 변경합니다
5. 의존성을 설치합니다
6. 빌드
7. aws 인증정보를 셋팅합니다
8. aws에 배포합니다. s3의 `assets` 폴더내부 파일을 재귀적으로 삭제 후 s3버킷에 현재 git actions 컨테이너의 `./dist` 파일과 동기화합니다.
9. cloudfront의 캐시를 무효화합니다(전부 무효)

- vercel 배포에 비하여 총 배포시간 약 20%내외 감소하였습니다.
- `main`브랜치에 **pr**시 build + test함수 검사하는 git actions를 추가하였습니다
-  이제 `package.json`내부 `packageManager`프로퍼티 추가 및 **lint-staged + husky** 정상작동 합니다


## 📷 Screenshots

![image](https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/87127340/f7dd49e6-636d-408d-adad-304d56d8ff0b)

## 🤔 고민사항

1. yarn v4의 zero install 활용방안(경로문제...😐)
2. yarn 캐싱 이용방안