### PR TITLE
[FIX]: 인게임 구독 중첩 안되도록 수정

### DIFF
--- a/src/pages/GamePage/hooks/useWebsocket.ts
+++ b/src/pages/GamePage/hooks/useWebsocket.ts
@@ -125,9 +125,7 @@ const useWebsocket = (roomId: number | null) => {
     );
   };
   const onIngameDisconnected = () => {
-    if (ingameSubscription.current) {
-      ingameSubscription.current.unsubscribe();
-    }
+    ingameSubscription.current?.unsubscribe();
   };
 
   const handleConnectIngame = (roomId: number) => {


### PR DESCRIPTION
## 📋 Issue Number
close #308 

## 💻 구현 내용

- 연속적으로 게임 진행시 인게임웹소켓 구독이 중첩되는 것을 방지하도록 수정했습니다.
- [StompJs 공식문서](https://stomp-js.github.io/api-docs/latest/classes/Client.html#unsubscribe)를 참조해서 인게임이 종료되면  unsubscribe을 하도록 구현

## 📷 Screenshots
<img width="478" alt="스크린샷 2024-04-04 오후 9 33 38" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/3340a631-cae9-42c2-aeae-7a94010d811f">

* 현재 게임을 연속으로 해도 더이상 중첩되지 않습니다.

## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->

<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
