### PR TITLE
[Refactor] UI 개선 - Code 길이 

### DIFF
--- a/src/pages/GamePage/GameCode/CodeContainer.tsx
+++ b/src/pages/GamePage/GameCode/CodeContainer.tsx
@@ -10,7 +10,7 @@ const CodeContainer = ({ codeItem }: CodeContainerProps) => {
   return (
     <>
       <div className='w-[60rem] select-none grow'>
-        <Highlight className='javascript'>{codeItem}</Highlight>
+        <Highlight className={'javascript' || 'java'}>{codeItem}</Highlight>
       </div>
     </>
   );

--- a/src/pages/GamePage/GameCode/GameCode.tsx
+++ b/src/pages/GamePage/GameCode/GameCode.tsx
@@ -20,7 +20,19 @@ const GameCode = ({ publishIngame, userId }: GameCodeProps) => {
   const codeList = useRef<I_Question[]>(ingameRoomRes.questions!);
 
   const convertedCodeList = codeList.current.map(({ question }) =>
-    question.split('\n').map((code) => code.trim())
+    question.split('\n').flatMap((code) => {
+      const trimedCode = code.trim();
+      const splitedTrimedCode = trimedCode.split(' ');
+      const SPLIT_INDEX = Math.floor((splitedTrimedCode.length - 1) / 2);
+
+      if (splitedTrimedCode.length > 1 && trimedCode.length > 50) {
+        return [
+          splitedTrimedCode.slice(0, SPLIT_INDEX).join(' '),
+          splitedTrimedCode.slice(SPLIT_INDEX).join(' '),
+        ];
+      }
+      return [trimedCode];
+    })
   );
 
   const handleNextRound = useCallback(() => {

--- a/src/pages/GamePage/GameCode/GameCode.tsx
+++ b/src/pages/GamePage/GameCode/GameCode.tsx
@@ -25,7 +25,7 @@ const GameCode = ({ publishIngame, userId }: GameCodeProps) => {
       const splitedTrimedCode = trimedCode.split(' ');
       const SPLIT_INDEX = Math.floor((splitedTrimedCode.length - 1) / 2);
 
-      if (splitedTrimedCode.length > 1 && trimedCode.length > 50) {
+      if (splitedTrimedCode.length > 1 && trimedCode.length > 65) {
         return [
           splitedTrimedCode.slice(0, SPLIT_INDEX).join(' '),
           splitedTrimedCode.slice(SPLIT_INDEX).join(' '),


### PR DESCRIPTION
## 📋 Issue Number
close #


- code 문제의 한 줄의 길이가 70을 넘어가면, **입력창을 넘어가는 문제**가 있었습니다.
<img width="499" alt="70자 넘어가면 input창에서 잘 안보임" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/8cc60fb7-8f63-460d-a706-0773e5b3b20d">


## 💻 구현 내용
- code 문제의 한 줄의 길이가 65를 넘어가면, **한 줄에 포함된 공백의 개수**에 따라 문제를 적절하게 잘랐습니다.

## 📷 Screenshots
<img width="486" alt="65자 넘어가면 입력란에서 많이 길어서 자름_1" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/a825b87f-713c-4fde-aed9-fb68bcfe34ee">
<img width="486" alt="65자 넘어가면 입력란에서 많이 길어서 자름_2" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/738a1239-5295-40f0-8358-c5b7f75256f0">


## 🤔 고민사항
<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
<!-- 하면서 생기는 막히는 부분, 모르는 점, 궁금한 점 -->
- 화면에 보이는 문제는 템플릿(공백, 줄넘김)이 적용되어 있는데 2가지 문제가 있습니다.

1. 좌우 길이가 길면 화면에서 문제가 잘리고 스크롤이 생깁니다. (사진 속 문제의 2번째 줄 참고)
    - <img width="399" alt="code 좌우 길이가 너무 길어서 잘림" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/d77618a4-f8b7-4305-8689-6ea504dcff87">

2. 상하 길이가 길면 트랙을 침범합니다.
    - <img width="740" alt="code 상하 길이가 너무 길어서 track 위로 넘침" src="https://github.com/Team-E2I4/Team-E2I4-TiKiTaza-FE/assets/66900221/b076f0aa-4421-4a3b-a7f1-e0e666c67928">

- highlight.js 가 적용된 문제 위에 **글자만 색상을 입히는 방법**은 찾아내지 못했습니다.. 😂
- 디자인을 바꾸게 된다면 트랙, 타수 그리고 정확도 계기판의 위치 조정도 필요할 것 같습니다!
- 좋은 의견 있다면 말씀해주세요!! 
<!-- 
📋 제출 전 check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
- 코드 정리를 한번 하셨나요?
	- 컨벤션 확인하셨나요?
	- UI와 도메인 로직을 잘 분리했나요?
	- depth가 너무 깊지는 않나요?
-->
